### PR TITLE
Add pytest-pyodide to requirements for GHA

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 black
 pre-commit
+pytest-pyodide
 pytest-playwright
 PyGithub
 PyYAML


### PR DESCRIPTION
Fix [ERROR  - ModuleNotFoundError: No module named 'pytest_pyodide'](https://github.com/BlackPythonDevs/blackpythondevs.github.io/actions/runs/6963700228/job/18950031279#step:6:54)