### PR TITLE
Fix mail to link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -49,7 +49,7 @@ bpdevs:
     - { platform: mastodon, user_url: "https://mastodon.social/@blackpythondevs" }
     - { platform: youtube, user_url: "https://www.youtube.com/@BlackPythonDevs" }
     - { platform: x, user_url: "https://x.com/blackpythondevs" }
-    - { platform: email, user_url: "contact@blackpythondevs.com" }
+    - { platform: email, user_url: "mailto:contact@blackpythondevs.com" }
 
 # Build settings
 markdown: kramdown


### PR DESCRIPTION
> mailto is a [Uniform Resource Identifier](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier) (URI) scheme for [email addresses](https://en.wikipedia.org/wiki/Email_addresses). It is used to produce [hyperlinks](https://en.wikipedia.org/wiki/Hyperlink) on [websites](https://en.wikipedia.org/wiki/Websites) that allow users to send an [email](https://en.wikipedia.org/wiki/Email) to a specific address directly from an [HTML](https://en.wikipedia.org/wiki/HTML) document, without having to copy it and entering it into an [email client](https://en.wikipedia.org/wiki/Email_client).