### PR TITLE
Add schema to conference URL

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -5,4 +5,4 @@
   summary: DjangoCon US 2024 has been announced! Join us for five days of inspiration,
     education, and networking opportunities centering around the Django web framework.
   type: both
-  url: 2024.djangocon.us/
+  url: https://2024.djangocon.us/


### PR DESCRIPTION
Without the schema, jekyll tries to append the url to the end of the base url. 

Example: `https://blackpythondevs.com/conferences/2024.djangocon.us/`

instead of 

`https://2024.djangocon.us/`

Fixes #339 