### PR TITLE
Add extra comment to template url field

### DIFF
--- a/.github/ISSUE_TEMPLATE/add_conference.yml
+++ b/.github/ISSUE_TEMPLATE/add_conference.yml
@@ -14,7 +14,7 @@ body:
   - type: input
     attributes:
       label: URL
-      description: The full URL of the conference (make sure to include `https://`.
+      description: The full URL of the conference (make sure to include `https://`).
       placeholder: https://example.com
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/add_conference.yml
+++ b/.github/ISSUE_TEMPLATE/add_conference.yml
@@ -14,7 +14,7 @@ body:
   - type: input
     attributes:
       label: URL
-      description: The URL of the conference.
+      description: The full URL of the conference (make sure to include `https://`.
       placeholder: https://example.com
     validations:
       required: true


### PR DESCRIPTION
Add extra emphasis on including the URL scheme when submitting a conference

Fixes #346 