### PR TITLE
Ensure the conference URL always has a scheme

### DIFF
--- a/_conferences/__main__.py
+++ b/_conferences/__main__.py
@@ -2,6 +2,7 @@ import os
 import re
 from datetime import datetime, time
 from pathlib import Path
+from urllib.parse import urlparse
 
 import yaml
 from github import Auth, Github
@@ -45,6 +46,13 @@ for issue in open_issues:
             re.DOTALL,
         )
 
+        # Check if there is a scheme (`https`) already in the parsed url
+        valid_url = None
+        if url_match is not None and url_match[1].strip() != "":
+            parsed_url = urlparse(url_match[1])
+            if "http" not in parsed_url.scheme.casefold():
+                valid_url = f"https://{url_match[1]}"
+
         if dates_match:
             conferenceDates = dates_match[1]
             # Parse the end date of the conference
@@ -54,7 +62,7 @@ for issue in open_issues:
             if endDate >= today:
                 conference = {
                     "name": name_match[1],
-                    "url": url_match[1],
+                    "url": valid_url,
                     "dates": dates_match[1],
                     "type": type_match[1],
                     "location": location_match[1],

--- a/_conferences/__main__.py
+++ b/_conferences/__main__.py
@@ -46,9 +46,14 @@ for issue in open_issues:
             re.DOTALL,
         )
 
-        # Check if there is a scheme (`https`) already in the parsed url
+        # Set a default value of None for when the url field isn't as expected
         valid_url = None
+
+        # Ensure the url field is not blank and the url matches the regex
         if url_match is not None and url_match[1].strip() != "":
+            # Parse the url and see if a scheme (`https`) is included in it
+            # If not, then prepend `https` to the url from the issue body
+            # This guards against the website thinking the passed in url is another page on https://blackpythondevs.com/
             parsed_url = urlparse(url_match[1])
             if "http" not in parsed_url.scheme.casefold():
                 valid_url = f"https://{url_match[1]}"


### PR DESCRIPTION
Update the parser to ensure that the scheme (`https`) is always added to the conference url. If the scheme is left off the url, then jekyll assumes that the url is another page on https://blackpythondevs.com/ (as seen in https://github.com/BlackPythonDevs/blackpythondevs.github.io/issues/339)

Fixes https://github.com/BlackPythonDevs/blackpythondevs.github.io/issues/353