### PR TITLE
Update to shedule in leadership summit page

### DIFF
--- a/leadership-summit-2024.md
+++ b/leadership-summit-2024.md
@@ -20,24 +20,24 @@ This year we're bringing presentation from folks all over the world to energize 
 
 The leadership Track is for BPD Members, Donors, and Distinguished Guests.
 
-- 8:00 - 9:00 am: Registration, Breakfast, and Mingling
-- 9:00 - 9:10 am: Welcome and Opening Remarks
-- 9:10-9:15: Gold Sponsor Lightning Talk
-- 9:20 - 10:05: Chop it Up Session with BPD Leaders
-- 10:05 - 10:15: Break
-- 10:15 - 11:00: Sponsor Talk
-- 11:00 - 1:00 pm: Lunch / Snack Break (BYOL)
+- 8:00 am - 9:00 am: Registration, Breakfast, and Mingling
+- 9:00 am - 9:10 am: Welcome and Opening Remarks
+- 9:10 am - 9:15 am: Gold Sponsor Lightning Talk
+- 9:20 am - 10:05 am: Chop it Up Session with BPD Leaders
+- 10:05 am - 10:15 am: Break
+- 10:15 am - 11:00 am: Sponsor Talk
+- 11:00 am - 1:00 pm: Lunch / Snack Break (BYOL)
 
 ### Community Building Track (Afternoon)
 
 Our Community track is available for everyone to join us in.
 
-- 12:00 - 1:00 am: Registration
-- 1:15 - 2:00 am: Keynote Address
-- 2:05 - 2:55: Interactive Session
-- 3:00 - 3:45 pm: Panel Discussion
-- 3:50 - 4:00 Breakout Session Prep
-- 4:00 - 5:00 pm: Breakout Sessions
-- 5:15 - 5:45 Breakout Session Recap
-- 5:45 - 6:00: Closing Remarks
-- 6:00 - 7:30 **Rooftop Happy Hour** sponsored by: **Caktus Group**
+- 12:00 pm - 1:00 pm: Registration
+- 1:15 pm - 2:00 pm: Keynote Address
+- 2:05 pm - 2:55 pm: Interactive Session
+- 3:00 pm - 3:45 pm: Panel Discussion
+- 3:50 pm - 4:00 pm: Breakout Session Prep
+- 4:00 pm - 5:00 pm: Breakout Sessions
+- 5:15 pm - 5:45 pm: Breakout Session Recap
+- 5:45 pm - 6:00 pm: Closing Remarks
+- 6:00 pm - 7:30 pm: **Rooftop Happy Hour** sponsored by: **Caktus Group**

--- a/leadership-summit-2024.md
+++ b/leadership-summit-2024.md
@@ -20,24 +20,24 @@ This year we're bringing presentation from folks all over the world to energize 
 
 The leadership Track is for BPD Members, Donors, and Distinguished Guests.
 
-- 8:00 am - 9:00 am: Registration, Breakfast, and Mingling
-- 9:00 am - 9:10 am: Welcome and Opening Remarks
-- 9:10 am - 9:15 am: Gold Sponsor Lightning Talk
-- 9:20 am - 10:05 am: Chop it Up Session with BPD Leaders
-- 10:05 am - 10:15 am: Break
-- 10:15 am - 11:00 am: Sponsor Talk
-- 11:00 am - 1:00 pm: Lunch / Snack Break (BYOL)
+- 8:00am - 9:00am: Registration, Breakfast, and Mingling
+- 9:00am - 9:10am: Welcome and Opening Remarks
+- 9:10am - 9:15am: Gold Sponsor Lightning Talk
+- 9:20am - 10:05am: Chop it Up Session with BPD Leaders
+- 10:05am - 10:15am: Break
+- 10:15am - 11:00am: Sponsor Talk
+- 11:00am - 1:00pm: Lunch / Snack Break (BYOL)
 
 ### Community Building Track (Afternoon)
 
 Our Community track is available for everyone to join us in.
 
-- 12:00 pm - 1:00 pm: Registration
-- 1:15 pm - 2:00 pm: Keynote Address
-- 2:05 pm - 2:55 pm: Interactive Session
-- 3:00 pm - 3:45 pm: Panel Discussion
-- 3:50 pm - 4:00 pm: Breakout Session Prep
-- 4:00 pm - 5:00 pm: Breakout Sessions
-- 5:15 pm - 5:45 pm: Breakout Session Recap
-- 5:45 pm - 6:00 pm: Closing Remarks
-- 6:00 pm - 7:30 pm: **Rooftop Happy Hour** sponsored by: **Caktus Group**
+- 12:00pm - 1:00pm: Registration
+- 1:15pm - 2:00pm: Keynote Address
+- 2:05pm - 2:55pm: Interactive Session
+- 3:00pm - 3:45pm: Panel Discussion
+- 3:50pm - 4:00pm: Breakout Session Prep
+- 4:00pm - 5:00pm: Breakout Sessions
+- 5:15pm - 5:45pm: Breakout Session Recap
+- 5:45pm - 6:00pm: Closing Remarks
+- 6:00pm - 7:30pm: **Rooftop Happy Hour** sponsored by: **Caktus Group**


### PR DESCRIPTION
[Issue #388](https://github.com/BlackPythonDevs/blackpythondevs.github.io/issues/388)

Updated the schedule in leadership summit page,

Before update:
12:00 - 1:00 am: Registration
1:15 - 2:00 am: Keynote Address
2:05 - 2:55: Interactive Session

After update:
12:00pm - 1:00pm: Registration
1:15pm - 2:00pm: Keynote Address
2:05pm - 2:55pm: Interactive Session