### PR TITLE
Changed schedule to show PSF as Silver sponsor #426

### DIFF
--- a/leadership-summit-2024.md
+++ b/leadership-summit-2024.md
@@ -61,7 +61,7 @@ The leadership Track is for BPD Members, Donors, and Distinguished Guests. In th
 - 9:10am - 9:15am: Gold Sponsor Lightning Talk - Caktus Group
 - 9:20am - 10:05am: Chop it Up Session with BPD Leaders
 - 10:05am - 10:15am: Break
-- 10:15am - 10:20am: Gold Sponsor Lightning Talk - Python Software Foundation
+- 10:15am - 10:20am: Silver Sponsor Lightning Talk - Python Software Foundation
 - 10:15am - 11:00am: Jay Miller: State of BPD
 - 11:00am - 1:00pm: Lunch / Snack Break (BYOL)
 


### PR DESCRIPTION
This PR updates the leadership_summit_2024.md file to reflect the correct sponsor tier for the Python Software Foundation.

Original text:
10:15 am - 10:20 am: Gold Sponsor Lightning Talk - Python Software Foundation
  
Updated text:
10:15 am - 10:20 am: Silver Sponsor Lightning Talk - Python Software Foundation

Reason for the change:

The Python Software Foundation should be listed as a Silver sponsor, not a Gold sponsor, in the schedule for the event.

Related Issue:
This change addresses issue #426.

