### PR TITLE
Fix inconsistent playwright test

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -14,8 +14,8 @@ routes = [
 
 @pytest.mark.parametrize("url", routes)
 def test_destination(
-        page: Page,
-        url: str,
+    page: Page,
+    url: str,
 ) -> None:
     """Test that the destinations page loads with seeded data"""
     # Create a destination
@@ -28,10 +28,10 @@ def test_destination(
 @pytest.mark.parametrize(
     "title, url",
     (
-            ("Acerca de", "/es/about/"),
-            ("Inicio", "/es/"),
-            ("Eventos", "/es/events/"),
-            ("Comunidad", "/es/community/"),
+        ("Acerca de", "/es/about/"),
+        ("Inicio", "/es/"),
+        ("Eventos", "/es/events/"),
+        ("Comunidad", "/es/community/"),
     ),
 )
 def test_headers_in_language(page: Page, title: str, url: str) -> None:
@@ -56,10 +56,10 @@ def test_switching_lang_es_about(page: Page) -> None:
 @pytest.mark.parametrize(
     "title, url",
     (
-            ("Kutuhusu", "/sw/about/"),
-            ("Nyumbani", "/sw/"),
-            ("Matukio", "/sw/events/"),
-            ("Jumuiya", "/sw/community/"),
+        ("Kutuhusu", "/sw/about/"),
+        ("Nyumbani", "/sw/"),
+        ("Matukio", "/sw/events/"),
+        ("Jumuiya", "/sw/community/"),
     ),
 )
 def test_headers_in_sw(page: Page, title: str, url: str) -> None:
@@ -84,11 +84,11 @@ def test_switching_lang_sw_about(page: Page) -> None:
 @pytest.mark.parametrize(
     "title, url",
     (
-            ("Black Python Devs | Home", "/"),
-            ("Black Python Devs | Blog", "/blog"),
-            ("Black Python Devs | About Us", "/about/"),
-            ("Black Python Devs | Events", "/events/"),
-            ("Black Python Devs | Community", "/community/"),
+        ("Black Python Devs | Home", "/"),
+        ("Black Python Devs | Blog", "/blog"),
+        ("Black Python Devs | About Us", "/about/"),
+        ("Black Python Devs | Events", "/events/"),
+        ("Black Python Devs | Community", "/community/"),
     ),
 )
 def test_bpdevs_title_en(page: Page, title: str, url: str) -> None:

--- a/tests/test.py
+++ b/tests/test.py
@@ -20,7 +20,8 @@ def test_destination(
     """Test that the destinations page loads with seeded data"""
     # Create a destination
     response = page.goto(f"{live_server_url}/{url}")
-    assert response.status == 200
+
+    assert response.status == 200  # Check that the page loaded successfully
     assert response.url.endswith(f"/{url}/")  # Load the index.html
 
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,5 +1,3 @@
-import time
-
 import pytest
 from playwright.sync_api import Page, expect
 
@@ -16,23 +14,23 @@ routes = [
 
 @pytest.mark.parametrize("url", routes)
 def test_destination(
-    page: Page,
-    url: str,
+        page: Page,
+        url: str,
 ) -> None:
     """Test that the destinations page loads with seeded data"""
     # Create a destination
     response = page.goto(f"{live_server_url}/{url}")
-    page.on("response", lambda response: expect(response.status).to_equal(200))
+    assert response.status == 200
     assert response.url.endswith(f"/{url}/")  # Load the index.html
 
 
 @pytest.mark.parametrize(
     "title, url",
     (
-        ("Acerca de", "/es/about/"),
-        ("Inicio", "/es/"),
-        ("Eventos", "/es/events/"),
-        ("Comunidad", "/es/community/"),
+            ("Acerca de", "/es/about/"),
+            ("Inicio", "/es/"),
+            ("Eventos", "/es/events/"),
+            ("Comunidad", "/es/community/"),
     ),
 )
 def test_headers_in_language(page: Page, title: str, url: str) -> None:
@@ -57,10 +55,10 @@ def test_switching_lang_es_about(page: Page) -> None:
 @pytest.mark.parametrize(
     "title, url",
     (
-        ("Kutuhusu", "/sw/about/"),
-        ("Nyumbani", "/sw/"),
-        ("Matukio", "/sw/events/"),
-        ("Jumuiya", "/sw/community/"),
+            ("Kutuhusu", "/sw/about/"),
+            ("Nyumbani", "/sw/"),
+            ("Matukio", "/sw/events/"),
+            ("Jumuiya", "/sw/community/"),
     ),
 )
 def test_headers_in_sw(page: Page, title: str, url: str) -> None:
@@ -85,11 +83,11 @@ def test_switching_lang_sw_about(page: Page) -> None:
 @pytest.mark.parametrize(
     "title, url",
     (
-        ("Black Python Devs | Home", "/"),
-        ("Black Python Devs | Blog", "/blog"),
-        ("Black Python Devs | About Us", "/about/"),
-        ("Black Python Devs | Events", "/events/"),
-        ("Black Python Devs | Community", "/community/"),
+            ("Black Python Devs | Home", "/"),
+            ("Black Python Devs | Blog", "/blog"),
+            ("Black Python Devs | About Us", "/about/"),
+            ("Black Python Devs | Events", "/events/"),
+            ("Black Python Devs | Community", "/community/"),
     ),
 )
 def test_bpdevs_title_en(page: Page, title: str, url: str) -> None:

--- a/tests/test.py
+++ b/tests/test.py
@@ -14,13 +14,6 @@ routes = [
 ]
 
 
-# Add a delay to each test to help with playwright race conditions
-@pytest.fixture(autouse=True)
-def slow_down_tests():
-    yield
-    time.sleep(1)
-
-
 @pytest.mark.parametrize("url", routes)
 def test_destination(
     page: Page,


### PR DESCRIPTION
The `Page.to_equal` function doesn't seem to exist in playwright for python. There is a NodeJS equivalent, but there is no supported GenericAssertion equivalent for python

https://playwright.dev/docs/api/class-genericassertions

While the overall test assertion would succeed, this would cause the teardown of the `test_destination` test to fail (viewable by adding `addopts = -v --tracing=on` to `pytest.ini`)

This is part of the error I would get prior to adding the code change. 
```
                ^^^^^^^^^^^^^^^^^^
  File "/Users/ao/blackpythondevs.github.io/.venv/lib/python3.11/site-packages/playwright/_impl/_impl_to_api_mapping.py", line 123, in wrapper_func
    return handler(
           ^^^^^^^^
  File "/Users/ao/blackpythondevs.github.io/tests/test.py", line 35, in <lambda>
    page.on("response", lambda response: expect(response.status).to_equal(200))
                                         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ao/blackpythondevs.github.io/.venv/lib/python3.11/site-packages/playwright/sync_api/__init__.py", line 142, in __call__
    raise ValueError(f"Unsupported type: {type(actual)}")
ValueError: Unsupported type: <class 'int'>
```

I think this should fix the playwright tests being inconsistent. If this _doesn't_ work, then I found that Playwright has a `slowmo` feature that just slows down the execution of the tests. 