### PR TITLE
Create a Comment Action for Automated Conference Issues

### DIFF
--- a/.github/workflows/conference.yml
+++ b/.github/workflows/conference.yml
@@ -53,3 +53,20 @@ jobs:
           labels: |
             report
             automated pr
+  add_comment:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Add comment to the issue
+      uses: actions/github-script@v6
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const issueNumber = context.payload.issue.number;
+          const comment = "Automated issue, no action is required."
+          
+          github.issues.createComment({
+            ...context.repo,
+            issue_number: issueNumber,
+            body: comment
+          });

--- a/.github/workflows/conference.yml
+++ b/.github/workflows/conference.yml
@@ -59,6 +59,7 @@ jobs:
     steps:
     - name: Add comment to the issue
       uses: actions/github-script@v6
+      if: ${{ github.event.issue.user.type != 'User' }} #adds comment only if the issue is created by a bot
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |


### PR DESCRIPTION
Implemented  a GitHub Action within the existing workflow located at .github/workflows/conference.yml that automatically adds a comment to issues created by this workflow. The comment should says:
"Automated issue, no action is required."
Requirements:
    Ensure that the comment does not apply to other manually created issues and only triggered when the conference actions is ran.

Closes #442 
