### PR TITLE
Add CFP Link and Deadline to Conference Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/add_conference.yml
+++ b/.github/ISSUE_TEMPLATE/add_conference.yml
@@ -1,7 +1,7 @@
 name: Add Conference
 description: Add Conference dates, location, speaking and other information that you would like shared
 title: "[CONFERENCE] <CONFERENCE NAME> YYYY"
-labels: ["conference"]
+labels: ["conference", "CFP"]
 body:
   - type: input
     id: conference_name
@@ -40,6 +40,22 @@ body:
       placeholder: "CITY, <REGION>, COUNTRY"
     validations:
       required: false
+  - type: input
+    id: cfp_link
+    attributes:
+      label: CFP Link
+      description: Provide the URL for the Call for Proposals (CFP) (make sure to include `https://`).
+      placeholder: "https://example.com/cfp"
+    validations:
+      required: true
+  - type: input
+    id: cfp_deadline
+    attributes:
+      label: CFP Deadline
+      description: Enter the deadline for submitting CFPs (YYYY-MM-DD).
+      placeholder: "YYYY-MM-DD"
+    validations:
+      required: true
   - type: textarea
     id: conference_description
     attributes:


### PR DESCRIPTION
issue #279 

Description of Changes Made to add_conference.Yml

Added CFP Link Field:

Introduced a brand new input area for the Call for Proposals (CFP) hyperlink, permitting convention organizers to provide a URL for their CFP. This field is marked as required.
Added CFP Deadline Field:

Added a new input subject for the CFP cut-off date, permitting organizers to specify the submission deadline. This area is also marked as required.
URL Validation:

Implemented validation for the CFP hyperlink area to ensure that users offer a legitimate URL format, enhancing information integrity.


