### PR TITLE
513 move issue comment workflow to its own workflow and modify confernce builder to run only when conference approved label is added

### DIFF
--- a/.github/workflows/conference.yml
+++ b/.github/workflows/conference.yml
@@ -51,44 +51,5 @@ jobs:
           delete-branch: true
           title: "[CONFERENCE] Update Conferences"
           labels: |
-            report
             automated pr
-
-  add_comment:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          token: ${{ env.GITHUB_TOKEN }}
-
-      - name: Setup Python environment
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.12"
-
-      - name: Install dependencies
-        run: pip install -r requirements-dev.txt
-
-      - name: Run script
-        env:
-          GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
-        run: |
-          python _conferences
-          pre-commit run --all-files --show-diff-on-failure
-
-      - name: Add comment to the issue
-        uses: actions/github-script@v6
-        if: ${{ github.event.action == 'opened' && startsWith(github.event.issue.title, '[CONFERENCE]') && contains(github.event.issue.labels.*.name, 'conference') }}
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const issueNumber = context.payload.issue.number;
-            const comment = "Automated issue, no action is required.";
-
-            await github.issues.createComment({
-              ...context.repo,
-              issue_number: issueNumber,
-              body: comment
-            });
+            conference

--- a/.github/workflows/conference.yml
+++ b/.github/workflows/conference.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    if: ${{ github.event.action == 'opened' && startsWith(github.event.issue.title, '[CONFERENCE]') && contains(github.event.issue.labels.*.name, 'conference_accepted') }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/conference_auto_respond.yml
+++ b/.github/workflows/conference_auto_respond.yml
@@ -1,0 +1,45 @@
+name: Conference AutoResponder
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  add_comment:
+    runs-on: ubuntu-latest
+
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Add initial comment to the issue
+        uses: actions/github-script@v6
+        if: ${{ github.event.action == 'opened' && startsWith(github.event.issue.title, '[CONFERENCE]') && contains(github.event.issue.labels.*.name, 'conference') }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issueNumber = context.payload.issue.number;
+            const comment = "Thank you for submitting this issue. A member of the triage team will review the information and followup on this request. There is no code action to be taken.";
+
+            await github.issues.createComment({
+              ...context.repo,
+              issue_number: issueNumber,
+              body: comment
+            });
+
+      - name: Add approved comment
+        uses: actions/github-script@v6
+        if: ${{ github.event.action == 'opened' && startsWith(github.event.issue.title, '[CONFERENCE]') && contains(github.event.issue.labels.*.name, 'conference_accepted') }}
+        with:
+          script: |
+            const issueNumber = context.payload.issue.number;
+            const comment = "Your conference submission has been accepted. You will shortly see your conference on the website."
+
+            await github.issues.createComment({
+              ...context.repo,
+              issue_number: issueNumber,
+              body: comment
+            });


### PR DESCRIPTION
- **add auto respond**
- **add if conditional**

## Issue Link 🔗:

**Issue**: #511

## Type of Change

- [x] Bug fix 🐞
- [ ] New feature/page
- [ ] Documentation update
- [ ] Other

## Description 📋

- **What:** Provide an overview of the issue this PR addresses. Explain the context and background information.

splits the workflow into two files so that they operate independently of one another.

## Checklist ✅

- [x] Followed the [Code of Conduct](https://github.com/BlackPythonDevs/blackpythondevs.github.io?tab=coc-ov-file) and [Contribution Guide](https://github.com/BlackPythonDevs/blackpythondevs.github.io/blob/469afd71943738b7209bfe56d5a4e35394fbaafc/CONTRIBUTING.md)
- [x] Ran `pre-commit run --all`
- [x] All tests pass locally
- [x] Added tests (if applicable)
- [x] Documentation updated (if applicable)

## Additional Notes & Screenshots

Add any additional notes or comments that might be helpful for the reviewers.
