### PR TITLE
Default image added for articles without images

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -5,6 +5,10 @@ layout: default
 <div class="hero-banner">
   <img src="{{page.featured_image}}" class="featured-image">
 </div>
+{%- else -%}
+<div class="hero-banner">
+    <img src="/assets/images/bpd_stacked.png" class="featured-image">
+</div>
 {%- endif -%}
 <article class="post h-entry" itemscope itemtype="http://schema.org/BlogPosting">
 


### PR DESCRIPTION
## Issue Link 🔗:

**Issue**: #533

## Type of Change

- [ ] Bug fix 🐞
- [x] New feature/page
- [ ] Documentation update
- [ ] Other

## Description 📋

- **What:** Added a default image to be displayed for articles without a custom image. 

- **Why:** To maintain the design and user experience of our website

- **How:** The default image is stored in the assets folder and automatically displayed when an article lacks a specified image.

## Checklist ✅

- [x] Followed the [Code of Conduct](https://github.com/BlackPythonDevs/blackpythondevs.github.io?tab=coc-ov-file) and [Contribution Guide](https://github.com/BlackPythonDevs/blackpythondevs.github.io/blob/469afd71943738b7209bfe56d5a4e35394fbaafc/CONTRIBUTING.md)
- [x] Ran `pre-commit run --all`
- [x] All tests pass locally
- [ ] Added tests (if applicable)
- [ ] Documentation updated (if applicable)

## Additional Notes & Screenshots

Add any additional notes or comments that might be helpful for the reviewers.
