### PR TITLE
modified dependabot to group Ruby and Python deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,10 @@ updates:
     commit-message:
       prefix: "bundle"
       include: "scope"
+    groups:
+      ruby-deps:
+        patterns:
+          - "*"
 
   # Configuration for pip
   - package-ecosystem: "pip"
@@ -38,3 +42,7 @@ updates:
     commit-message:
       prefix: "pip"
       include: "scope"
+    groups:
+      python-deps:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Issue Link 🔗:

**Issue**: #607 

## Type of Change

- [ ] Bug fix 🐞
- [x] New feature/page
- [ ] Documentation update
- [ ] Other

## Description 📋

modified dependabot to group Ruby and Python dependencies into each PRs 

## Checklist ✅

- [x] Followed the [Code of Conduct](https://github.com/BlackPythonDevs/blackpythondevs.github.io?tab=coc-ov-file) and [Contribution Guide](https://github.com/BlackPythonDevs/blackpythondevs.github.io/blob/469afd71943738b7209bfe56d5a4e35394fbaafc/CONTRIBUTING.md)
- [x] Ran `pre-commit run --all`
- [x] All tests pass locally
- [ ] Added tests (if applicable)
- [ ] Documentation updated (if applicable)

## Additional Notes & Screenshots

Add any additional notes or comments that might be helpful for the reviewers.
