### PR TITLE
Remove extra sort when listing out leadership council

### DIFF
--- a/about.html
+++ b/about.html
@@ -82,7 +82,7 @@ title: About Us
   <article>
     <p>We also vet our actions through our Black Python Devs Leadership Council made up of members who serve as Python Community leaders on a local, regional, or global scale.</p>
     <div>
-      {% assign council = site.data.leadership.Council | sort %} {% for leader in council | sort %}
+      {% assign council = site.data.leadership.Council | sort %} {% for leader in council %}
       <ul>
         <li><strong>{{ leader }}</strong></li>
       </ul>


### PR DESCRIPTION
## Issue Link 🔗:

**Issue**: #652

## Type of Change

- [x] Bug fix 🐞
- [ ] New feature/page
- [ ] Documentation update
- [ ] Other

## Description 📋

### What:
When starting up the server locally, we see this liquid warning

> ```
> Liquid Warning: Liquid syntax error (line 79): Expected end_of_string but found pipe in "leader in council | sort" in about.html
> ```

This means that liquid is expecting the statement to end after `leader in council`, but it sees that there is `| sort` following, and it  is confused by that.

### Why

While this is only a warning, fixing this bug helps to resolve a tiny bit of confusion when seeing the warning

### How

Because we're already sorting the leadership council when assigning the `council` variable, there's no need to try and sort it again in the later `for` loop. So I just removed the `| sort` function and verified that the order of the leadership council page remains the exact same


## Checklist ✅

- [x] Followed the [Code of Conduct](https://github.com/BlackPythonDevs/blackpythondevs.github.io?tab=coc-ov-file) and [Contribution Guide](https://github.com/BlackPythonDevs/blackpythondevs.github.io/blob/469afd71943738b7209bfe56d5a4e35394fbaafc/CONTRIBUTING.md)
- [x] Ran `pre-commit run --all`
- [x] All tests pass locally
- [ ] Added tests (if applicable)
- [ ] Documentation updated (if applicable)

## Additional Notes & Screenshots

Add any additional notes or comments that might be helpful for the reviewers.
