### PR TITLE
Simple image resize scripts

### DIFF
--- a/image_resize.py
+++ b/image_resize.py
@@ -1,0 +1,20 @@
+from PIL import Image
+import os
+
+folder = "assets/images"
+new_size = (800, 600)
+
+for filename in os.listdir(folder):
+    if filename.lower().endswith(('.jpg', '.jpeg', '.png', '.webp')):
+        file_path = os.path.join(folder, filename)
+        original_size = os.path.getsize(file_path)
+
+        with Image.open(file_path) as img:
+            img.thumbnail(new_size)
+            img.save(file_path)
+
+        new_size_bytes = os.path.getsize(file_path)
+        reduction = original_size - new_size_bytes
+        percent = (reduction / original_size) * 100 if original_size else 0
+
+        print(f"✅ Resized: {filename} | Saved {reduction//1024}KB ({percent:.1f}%)")

--- a/image_resize.py
+++ b/image_resize.py
@@ -1,20 +1,83 @@
 from PIL import Image
 import os
 
-folder = "assets/images"
-new_size = (800, 600)
 
-for filename in os.listdir(folder):
-    if filename.lower().endswith(('.jpg', '.jpeg', '.png', '.webp')):
-        file_path = os.path.join(folder, filename)
-        original_size = os.path.getsize(file_path)
+def crop_to_ratio(img, target_ratio):
+    """Crop image to target ratio (e.g., 16/9 or 1/1) without distortion."""
+    width, height = img.size
+    current_ratio = width / height
 
+    if current_ratio > target_ratio:
+        # Crop width
+        new_width = int(height * target_ratio)
+        left = (width - new_width) // 2
+        return img.crop((left, 0, left + new_width, height))
+    else:
+        # Crop height
+        new_height = int(width / target_ratio)
+        top = (height - new_height) // 2
+        return img.crop((0, top, width, top + new_height))
+
+def process_image(file_path, ratio, max_size, format="webp"):
+    """Process and overwrite the original image: crop, resize, convert format."""
+    try:
         with Image.open(file_path) as img:
-            img.thumbnail(new_size)
-            img.save(file_path)
+            # Crop to target ratio
+            if ratio:
+                img = crop_to_ratio(img, ratio)
+            
+            # Resize to max dimensions
+            if max_size:
+                img.thumbnail(max_size)
+            
+            # convert to webp if no transparency
+            if format.lower() == "webp" and img.mode != "RGBA":
+                file_path = os.path.splitext(file_path)[0] + ".webp"
+                img.save(file_path, "webp", optimize=True, quality=85)
+            else:
+                img.save(file_path, optimize=True)
+            
+            print(f"✅ Overwritten: {file_path}")
+    except Exception as e:
+        print(f"❌ Failed {file_path}: {str(e)}")
 
-        new_size_bytes = os.path.getsize(file_path)
-        reduction = original_size - new_size_bytes
-        percent = (reduction / original_size) * 100 if original_size else 0
+def main():
+    folder = "assets/images" 
+    
+    # Rules for image types
+    rules = [
+        {
+            "suffix": ["banner", "header"],
+            "ratio": 16/9,
+            "max_size": (1920, 1080),  # Min size enforced via cropping
+            "format": "webp"
+        },
+        {
+            "suffix": ["thumb", "profile"],
+            "ratio": 1/1,
+            "max_size": (800, 800),
+            "format": "webp"
+        }
+    ]
 
-        print(f"✅ Resized: {filename} | Saved {reduction//1024}KB ({percent:.1f}%)")
+    for filename in os.listdir(folder):
+        if filename.lower().endswith(('.jpg', '.jpeg', '.png', '.webp')):
+            file_path = os.path.join(folder, filename)
+            
+            # Apply first rule
+            matched_rule = None
+            for rule in rules:
+                if any(keyword in filename.lower() for keyword in rule["suffix"]):
+                    matched_rule = rule
+                    break
+            
+            # no cropping, resize to 800x600, convert to webp if no transparency
+            if not matched_rule:
+                with Image.open(file_path) as img:
+                    format = "webp" if img.mode != "RGBA" else "png"
+                matched_rule = {"ratio": None, "max_size": (800, 600), "format": format}
+
+            process_image(file_path, **matched_rule)
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,5 @@ pytest-playwright
 pytest-xprocess
 axe-core-python==0.1.0
 axe-playwright-python==0.1.4
+Pillow==11.2.1
+


### PR DESCRIPTION
## Issue Link 🔗:

**Issue**: #711 

## Type of Change

- [ ] Bug fix 🐞
- [x] New feature/page
- [ ] Documentation update
- [ ] Other

## Description 📋
The script is ran with the command `python3 image_resize.py` from the root directory i.e where the `requirements.txt` file is located.

### update
 - Added rules for cropping, resizing, and webp conversion
- Automatically crop banners/headers to 16:9 (max 1920x1080) and thumbs/profiles to 1:1 (max 800x800)  
- Convert non-transparent images to optimized webp
- Preserve aspect ratio with centered cropping (no distortion)  
- Default unmatched images to 800x600 (no forced upscaling)  

## Checklist ✅

- [ ] Followed the [Code of Conduct](https://github.com/BlackPythonDevs/blackpythondevs.github.io?tab=coc-ov-file) and [Contribution Guide](https://github.com/BlackPythonDevs/blackpythondevs.github.io/blob/469afd71943738b7209bfe56d5a4e35394fbaafc/CONTRIBUTING.md)
- [x] Ran `pre-commit run --all`
- [x] All tests pass locally
- [x] Added tests (if applicable)
- [ ] Documentation updated (if applicable)

## Additional Notes & Screenshots
![image](https://github.com/user-attachments/assets/bc6cbcf4-9635-4162-ac63-777dc41519eb)
