### PR TITLE
Update footer to include both events pages

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,7 @@ index.html
 assets/js/jquery.min.js
 assets/js/index.js
 _layouts/*.html
+/_layouts/_includes/pitch_deck.html
 _includes/conferences.html
 _includes/header.html
 _includes/social.html

--- a/_data/foundational_supporters.json
+++ b/_data/foundational_supporters.json
@@ -1,18 +1,5 @@
 {
-  "2025": [
-    "Aman Singh",
-    "Angela Andrews",
-    "Carol Willing",
-    "Hugh Dyar",
-    "Jeremy Carbaugh",
-    "Jonathan Banafato",
-    "Mike Fiedler",
-    "Ned Batchelder",
-    "Peter Pinch",
-    "Savannah Ostrowski",
-    "Tim Schilling",
-    "Vance Arocho"
-  ],
+  "2025": ["Aman Singh", "Angela Andrews", "Carol Willing", "Hugh Dyar", "Jeremy Carbaugh", "Jonathan Banafato", "Mike Fiedler", "Ned Batchelder", "Peter Pinch", "Savannah Ostrowski", "Tim Schilling", "Vance Arocho"],
   "2024": [
     "Albert Sweigart",
     "Angela Andrews",

--- a/_layouts/_includes/footer.html
+++ b/_layouts/_includes/footer.html
@@ -11,7 +11,8 @@
         <h3>Quick link</h3>
         <ul>
           <li><a href="/about.html">About Us</a></li>
-          <li><a href="/events/">Events</a></li>
+          <li><a href="/bdp-events/">Our Events</a></li>
+          <li><a href="/sponsored-events/">Sponsored Events</a></li>
           <li><a href="/community/">Community</a></li>
           <li><a href="/support/">Support</a></li>
         </ul>

--- a/image_resize.py
+++ b/image_resize.py
@@ -18,6 +18,7 @@ def crop_to_ratio(img, target_ratio):
         top = (height - new_height) // 2
         return img.crop((0, top, width, top + new_height))
 
+
 def process_image(file_path, ratio, max_size, format="webp"):
     """Process and overwrite the original image: crop, resize, convert format."""
     try:
@@ -25,52 +26,53 @@ def process_image(file_path, ratio, max_size, format="webp"):
             # Crop to target ratio
             if ratio:
                 img = crop_to_ratio(img, ratio)
-            
+
             # Resize to max dimensions
             if max_size:
                 img.thumbnail(max_size)
-            
+
             # convert to webp if no transparency
             if format.lower() == "webp" and img.mode != "RGBA":
                 file_path = os.path.splitext(file_path)[0] + ".webp"
                 img.save(file_path, "webp", optimize=True, quality=85)
             else:
                 img.save(file_path, optimize=True)
-            
+
             print(f"✅ Overwritten: {file_path}")
     except Exception as e:
         print(f"❌ Failed {file_path}: {str(e)}")
 
+
 def main():
-    folder = "assets/images" 
-    
+    folder = "assets/images"
+
     # Rules for image types
     rules = [
         {
             "suffix": ["banner", "header"],
-            "ratio": 16/9,
+            "ratio": 16 / 9,
             "max_size": (1920, 1080),  # Min size enforced via cropping
-            "format": "webp"
+            "format": "webp",
         },
         {
             "suffix": ["thumb", "profile"],
-            "ratio": 1/1,
+            "ratio": 1 / 1,
             "max_size": (800, 800),
-            "format": "webp"
-        }
+            "format": "webp",
+        },
     ]
 
     for filename in os.listdir(folder):
-        if filename.lower().endswith(('.jpg', '.jpeg', '.png', '.webp')):
+        if filename.lower().endswith((".jpg", ".jpeg", ".png", ".webp")):
             file_path = os.path.join(folder, filename)
-            
+
             # Apply first rule
             matched_rule = None
             for rule in rules:
                 if any(keyword in filename.lower() for keyword in rule["suffix"]):
                     matched_rule = rule
                     break
-            
+
             # no cropping, resize to 800x600, convert to webp if no transparency
             if not matched_rule:
                 with Image.open(file_path) as img:
@@ -78,6 +80,7 @@ def main():
                 matched_rule = {"ratio": None, "max_size": (800, 600), "format": format}
 
             process_image(file_path, **matched_rule)
+
 
 if __name__ == "__main__":
     main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,3 @@ pytest-xprocess
 axe-core-python==0.1.0
 axe-playwright-python==0.1.4
 Pillow==11.2.1
-


### PR DESCRIPTION
The main site has 2 events links:
- BPD Events
- Sponsored Events

The update to the footer replaces the outdated `events` link and inserts the 2 new events links

## Issue Link 🔗:

**Issue**: #725 

## Type of Change

- [x] Bug fix 🐞
- [ ] New feature/page
- [ ] Documentation update
- [ ] Other

## Description 📋

- **What:** Events tag in footer is outdated
- **Why/How:** The update will show both BPD Events and Sponsored Events in the footer.

## Checklist ✅

- [x] Followed the [Code of Conduct](https://github.com/BlackPythonDevs/blackpythondevs.github.io?tab=coc-ov-file) and [Contribution Guide](https://github.com/BlackPythonDevs/blackpythondevs.github.io/blob/469afd71943738b7209bfe56d5a4e35394fbaafc/CONTRIBUTING.md)
- [x] Ran `pre-commit run --all`
- [ ] All tests pass locally
- [ ] Added tests (if applicable)
- [ ] Documentation updated (if applicable)

## Additional Notes & Screenshots

Add any additional notes or comments that might be helpful for the reviewers.
