### PR TITLE
Add accordion-style display for previous years' sponsored events

### DIFF
--- a/_data/sponsored_events.json
+++ b/_data/sponsored_events.json
@@ -1,5 +1,8 @@
 {
-  "2024": ["PyTexas", "PyOhio", "PyCon Africa", "PyCon South Africa", "PyCon Zimbabwe", "PyCon Nigeria", "IndabaX - Botswana", "PyCon Uganda", "PyHo - Ghana"],
+  "2024": {
+    "Africa": ["PyCon Africa", "PyCon South Africa", "PyCon Zimbabwe", "PyCon Nigeria", "IndabaX - Botswana", "PyCon Uganda", "PyHo - Ghana"],
+    "North America": ["PyTexas", "PyOhio"]
+  },
   "2025": {
     "Africa": ["Django Girls - Ho", "PyCon Africa", "DjangoCon Africa", "IndabaX - Botswana", "PyCon Namibia", "PyTogo", "Zero to Hero Mentorship Program - Nigeria"],
     "North America": ["PyTexas Foundation", "PyOhio", "PyBeach"],

--- a/_layouts/sponsored-events.html
+++ b/_layouts/sponsored-events.html
@@ -14,16 +14,28 @@
   <p>Here is a look at events this year that we've supported:</p>
   </section>
 
+
   <section>
-    <h2>Events Sponsored in {{year}}</h2>
-  <section class="grid">
-    {% for segment in data[year] | sort %}
-    <article>
-    <h3>{{segment}}</h3>
-      {% for event in data[year][segment] | sort %}
-        <p>{{event}}</p>
+    <h2>Events Sponsored by year</h2>
+    {% for segment_year in data | sort(reverse=True) %}
+    {% if segment_year == year %}
+    <details name="{{segment_year}}" open>
+    {% else %}
+    <details name="{{segment_year}}">
+    {% endif %}
+    <summary>{{segment_year}}</summary>
+      <section class="grid">
+      {% for segment in data[segment_year] | sort %}
+      <article>
+      <h3>{{segment}}</h3>
+        {% for event in data[segment_year][segment] | sort %}
+          <p>{{event}}</p>
+        {% endfor %}
+      </article>
       {% endfor %}
-    </article>
+      </section>
+    </details>
+    <hr/>
     {% endfor %}
   </section>
 


### PR DESCRIPTION
## Summary
- Added accordion-style navigation to the sponsored events page showing events by year and region
- Replaced empty events.json with structured sponsored_events.json containing 2024 and 2025 event data
- Updated sponsored events page template to display events organized by year with collapsible sections
- Removed JetBrains logo from sponsors section
- Added proper event categorization by geographic regions (Africa, North America, South America)

## Test plan
- [x] Verify the sponsored events page loads correctly at /sponsored-events
- [x] Test that accordion sections expand and collapse properly
- [x] Confirm all event data displays correctly within regional categories
- [x] Validate the layout is responsive and accessible
- [x] Check that the current year (2025) accordion is open by default

🤖 Generated with [Claude Code](https://claude.ai/code)