### PR TITLE
Add Django Girls - Koforidua to African sponsored events

### DIFF
--- a/_data/sponsored_events.json
+++ b/_data/sponsored_events.json
@@ -4,7 +4,7 @@
     "North America": ["PyTexas", "PyOhio"]
   },
   "2025": {
-    "Africa": ["Django Girls - Ho", "PyCon Africa", "DjangoCon Africa", "IndabaX - Botswana", "PyCon Namibia", "PyTogo", "Zero to Hero Mentorship Program - Nigeria"],
+    "Africa": ["Django Girls - Koforidua", "Django Girls - Ho", "PyCon Africa", "DjangoCon Africa", "IndabaX - Botswana", "PyCon Namibia", "PyTogo", "Zero to Hero Mentorship Program - Nigeria"],
     "North America": ["PyTexas Foundation", "PyOhio", "PyBeach"],
     "South America": ["Ubuntu Tech - Colombia", "Django Girls - Colombia"]
   }


### PR DESCRIPTION
## Summary
• Added Django Girls - Koforidua to the 2025 Africa sponsored events list

## Test plan
- [x] Verified JSON format is valid
- [x] Confirmed event is added to correct year and region

🤖 Generated with [Claude Code](https://claude.ai/code)