### PR TITLE
Fix wrong title name for events page

### DIFF
--- a/_layouts/event-list.html
+++ b/_layouts/event-list.html
@@ -1,7 +1,7 @@
 {% extends "default.html" %}
 {% block content %}
 <section>
-<h1>Blog Posts</h1>
+  <h1>{{title}}</h1>
     {% for page in pages %}
       <article>
         <h2><a href="{{ page }}.html">

--- a/app.py
+++ b/app.py
@@ -70,6 +70,7 @@ class Pages(Collection):
 
 @app.collection
 class BPDEvents(Collection):
+    title = "BPD Events"
     Parser = MarkdownPageParser
     content_path = "events"
     template = "default.html"

--- a/events/leadership-summit-2024.md
+++ b/events/leadership-summit-2024.md
@@ -1,7 +1,7 @@
 ---
 layout: event
 lang: en
-title: Black Python Devs Leadership Summit
+title: Black Python Devs Leadership Summit 2024
 tito_event: black-python-devs/leadership-summit
 event_banner: "/assets/images/bpd-summit-card-deck.jpg"
 commitchange_campaign_id: 5515


### PR DESCRIPTION
## Summary
- Fixed hardcoded "Blog Posts" title in event-list.html layout to use dynamic title
- Added title property to BPDEvents collection in app.py
- Updated Leadership Summit event title to include 2024 year

## Test plan
- [ ] Verify events page displays "BPD Events" as the title instead of "Blog Posts"
- [ ] Verify Leadership Summit event shows "Black Python Devs Leadership Summit 2024"
- [ ] Check that the site builds and renders correctly

🤖 Generated with [Claude Code](https://claude.ai/code)