### PR TITLE
Adds PyCon Nigeria 2025

### DIFF
--- a/_data/sponsored_events.json
+++ b/_data/sponsored_events.json
@@ -4,7 +4,7 @@
     "North America": ["PyTexas", "PyOhio"]
   },
   "2025": {
-    "Africa": ["Django Girls - Koforidua", "Django Girls - Ho", "PyCon Africa", "DjangoCon Africa", "IndabaX - Botswana", "PyCon Namibia", "PyTogo", "Zero to Hero Mentorship Program - Nigeria"],
+    "Africa": ["Django Girls - Koforidua", "Django Girls - Ho", "PyCon Africa", "DjangoCon Africa", "IndabaX - Botswana", "PyCon Namibia", "PyTogo", "Zero to Hero Mentorship Program - Nigeria", "PyCon Nigeria"],
     "North America": ["PyTexas Foundation", "PyOhio", "PyBeach", "PyBay"],
     "South America": ["Ubuntu Tech - Colombia", "Django Girls - Colombia"]
   }


### PR DESCRIPTION
Adds PyCon Nigeria to the Supported Sponsors List for 2025