### PR TITLE
Fix title display for all pages

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="{% if description%}{{ description | escape }}{% else %}{{ site.description }}{% endif %}" />
-    <title>{% if title %}{{ site.title }} | {{ title }}{% else %}{{ site.title }}{% endif %}</title>
+    <title>{% if title == 'Index' %}Black Python Devs{% elif title %}{{ title }} | Black Python Devs{% else %}Black Python Devs{% endif %}</title>
     <link rel="stylesheet" href="{{ '/assets/css/pico.min.css' }}" />
     <link rel="stylesheet" href="{{ '/assets/css/pico.colors.min.css' }}" />
     <link rel="stylesheet" href="{{ '/assets/css/bpd.css' }}" />


### PR DESCRIPTION
**Issue**: #756 

## Type of Change

- [x] Bug fix 🐞
- [ ] New feature/page
- [ ] Documentation update
- [ ] Other

## Description 📋

### What

- Fix Index page to show just `Black Python Devs` instead of `Index | Black Python Devs`
- Fix other pages to show proper `<page-title> | Black Python Devs` format



## Checklist ✅

- [x] Followed the [Code of Conduct](https://github.com/BlackPythonDevs/blackpythondevs.github.io?tab=coc-ov-file) and [Contribution Guide](https://github.com/BlackPythonDevs/blackpythondevs.github.io/blob/469afd71943738b7209bfe56d5a4e35394fbaafc/CONTRIBUTING.md)
- [x] Ran `pre-commit run --all`
- [ ] All tests pass locally
- [ ] Added tests (if applicable)
- [ ] Documentation updated (if applicable)

## Additional Notes & Screenshots

Add any additional notes or comments that might be helpful for the reviewers.
