### PR TITLE
Add Code of Conduct link to footer navigation

### DIFF
--- a/_layouts/_includes/footer.html
+++ b/_layouts/_includes/footer.html
@@ -16,6 +16,7 @@
           <li><a href="/partnerships.html">Partnerships</a></li>
           <li><a href="/community.html">Community</a></li>
           <li><a href="/support.html">Support</a></li>
+          <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
         </ul>
       </div>
       <!-- Contact Us Section -->


### PR DESCRIPTION
## Summary
- Added "Code of Conduct" link to Quick Links section in footer
- Links to /code-of-conduct.html
- Improves discoverability of community guidelines

## Test plan
- [x] Verify the Code of Conduct link appears in the footer
- [x] Confirm the link points to the correct page (/code-of-conduct.html)
- [x] Check footer layout remains intact on various screen sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)