### PR TITLE
Add Code of Conduct link to footer

### DIFF
--- a/_layouts/_includes/footer.html
+++ b/_layouts/_includes/footer.html
@@ -16,6 +16,7 @@
           <li><a href="/partnerships.html">Partnerships</a></li>
           <li><a href="/community.html">Community</a></li>
           <li><a href="/support.html">Support</a></li>
+          <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
         </ul>
       </div>
       <!-- Contact Us Section -->


### PR DESCRIPTION
This PR adds a link to the Code of Conduct page in the footer 'Quick link' section. Fixes #765.