### PR TITLE
Refactor author frontmatter to list

### DIFF
--- a/.frontmatter_check.yaml
+++ b/.frontmatter_check.yaml
@@ -8,4 +8,3 @@ patterns:
       - field_name: lang
       - field_name: layout
       - field_name: title
-      - field_name: author

--- a/_layouts/blog-list.html
+++ b/_layouts/blog-list.html
@@ -12,7 +12,7 @@
           {% if page.description %}
           <p>{{page.description}}</p>
           {% endif %}
-          <small>{{page.author | join(", ")}} - <strong>{{page.date | format_datetime}}</strong></small>
+          <small>{% if page.author %}{{page.author | join(", ")}} - {% endif %}<strong>{{page.date | format_datetime}}</strong></small>
         </div>
       </article>
     {% endfor %}

--- a/_layouts/event-list.html
+++ b/_layouts/event-list.html
@@ -7,7 +7,7 @@
         <h2><a href="{{ page }}.html">
           {{ page.title }}
         </a></h2>
-        <small>{{page.author}} {{page.date}}</small>
+        <small>{% if page.author %}{{page.author | join(", ")}} {% endif %}{{page.date}}</small>
       </article>
     {% endfor %}
     </section>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -15,13 +15,14 @@
     <header class="post-header">
       <h1 class="post-title p-name" itemprop="name headline">{{ title }}</h1>
       <p class="post-meta">
+        {% if author %}
         <span itemprop="author" itemscope itemtype="http://schema.org/Person">
           {% for person in author %}
           <span class="p-author h-card" itemprop="name">{{ person }}</span>
           {% if not loop.last %}, {% endif %}
           {% endfor %}
         </span>
-
+        {% endif %}
       </p>
     </header>
     <div class="post-content e-content" itemprop="articleBody">
@@ -31,6 +32,7 @@
 </section>
 
 <section>
+  {% if author %}
   {% for author_name in author %}
     {% set author_data = SITE_AUTHORS | selectattr("name", "equalto", author_name) | first %}
     {% if author_data and author_data.bio %}
@@ -39,6 +41,7 @@
       <p>{{author_data.bio|e}}</p>
     {% endif %}
   {% endfor %}
+  {% endif %}
 </section>
 
 {% endblock %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -30,13 +30,15 @@
   </article>
 </section>
 
-{% set author = authors %}
 <section>
-  {% if author and author.bio %}
-  <hr />
-    <h3>About {{author.name}}</h3>
-    <p>{{author.bio|e}}</p>
-  </section>
-  {% endif %}
+  {% for author_name in author %}
+    {% set author_data = SITE_AUTHORS | selectattr("name", "equalto", author_name) | first %}
+    {% if author_data and author_data.bio %}
+      <hr />
+      <h3>About {{author_data.name}}</h3>
+      <p>{{author_data.bio|e}}</p>
+    {% endif %}
+  {% endfor %}
+</section>
 
 {% endblock %}

--- a/app.py
+++ b/app.py
@@ -31,6 +31,9 @@ app.site_vars["locales"] = ["en"]
 app.site_vars["navigation"] = navigation
 app.site_vars["DATETIME_FORMAT"] = "%d %b %Y"
 app.site_vars["year"] = str(datetime.date.today().year)
+app.site_vars["SITE_AUTHORS"] = json.loads(
+    pathlib.Path("_data/authors.json").read_text()
+)
 
 
 @app.page

--- a/scripts/check_author_list.py
+++ b/scripts/check_author_list.py
@@ -17,6 +17,11 @@ def check_authors():
                 if not isinstance(author, list):
                     print(f"Error: Author in {file_path} is not a list: {author}")
                     failed = True
+                elif len(author) == 0:
+                    print(
+                        f"Error: Author list in {file_path} is empty. Remove the field if there is no author."
+                    )
+                    failed = True
         except Exception as e:
             print(f"Error processing {file_path}: {e}")
             failed = True


### PR DESCRIPTION
## Summary
This PR addresses issue #707 by ensuring that the `author` field in frontmatter is always a list if present. It also updates the templates to gracefully handle posts that do not have an `author` field.

Changes included:
- Refactored `author` frontmatter to be a list in `_posts`.
- Updated `_layouts/post.html` to iterate over the `author` list and look up bios from `_data/authors.json`.
- Updated `_layouts/post.html`, `_layouts/blog-list.html`, and `_layouts/event-list.html` to conditionally render the author section only if the `author` field exists.
- Added `scripts/check_author_list.py` as a pre-commit hook to enforce that `author` is a list and not empty if present.

## Note
The `check_author_list.py` script is a temporary fix. The functionality to enforce list types for frontmatter fields will exist in a future version of `frontmatter-check`.

An issue should be created to update to the new version of `frontmatter-check` when it becomes available, at which point this script can be removed.

## Note
The `scripts/check_author_list.py` script is a temporary fix. This functionality will be included in a future version of `frontmatter-check`.

TODO: Update to the new version of `frontmatter-check` once available (see linked issue).