### PR TITLE
Fix broken events links

### DIFF
--- a/_layouts/_includes/footer.html
+++ b/_layouts/_includes/footer.html
@@ -11,7 +11,7 @@
         <h3>Quick link</h3>
         <ul>
           <li><a href="/about.html">About Us</a></li>
-          <li><a href="/events/">Events</a></li>
+          <li><a href="/events.html">Events</a></li>
           <li><a href="/partnerships.html">Partnerships</a></li>
           <li><a href="/about.html#join-the-community">Community</a></li>
           <li><a href="/support.html">Support</a></li>

--- a/app.py
+++ b/app.py
@@ -65,7 +65,7 @@ class BPDEvents(Collection):
     Parser = MarkdownPageParser
     content_path = "events"
     template = "default.html"
-    routes = ["./-events"]
+    routes = ["./bpd-events"]
 
 
 @app.collection


### PR DESCRIPTION
## Issue Link 🔗:

**Issue**: No issue filed

## Type of Change

- [x] Bug fix 🐞
- [ ] New feature/page
- [ ] Documentation update
- [ ] Other

## Description 📋

- **What:** Update rendered links to match the paths generated by the app.

- **Why:** The events link in the page footer and the link to the 2024 Black Python Devs Leadership Summit event page currently 404. 

- **How:** Makes navigation to the events page and Leadership Summit easier via footer link.

## Checklist ✅

- [x] Followed the [Code of Conduct](https://github.com/BlackPythonDevs/blackpythondevs.github.io?tab=coc-ov-file) and [Contribution Guide](https://github.com/BlackPythonDevs/blackpythondevs.github.io/blob/469afd71943738b7209bfe56d5a4e35394fbaafc/CONTRIBUTING.md)
- [x] Ran `pre-commit run --all`
- [ ] All tests pass locally
- [ ] Added tests (if applicable)
- [ ] Documentation updated (if applicable)

## Additional Notes & Screenshots

No additional notes.
