### PR TITLE
Add Sarah Drasner to 2026 foundational supporters

### DIFF
--- a/_data/foundational_supporters.json
+++ b/_data/foundational_supporters.json
@@ -1,4 +1,5 @@
 {
+  "2026": ["Sarah Drasner"],
   "2025": [
     "Albert Sweigart",
     "Alla Barbalat",


### PR DESCRIPTION
## Summary
- Adds a new `2026` section to `_data/foundational_supporters.json`
- Adds Sarah Drasner as the first 2026 foundational supporter

Closes #869

## Test plan
- [ ] Verify the JSON is valid and the supporters page renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)