### PR TITLE
Add 13 missing member countries to about page map

### DIFF
--- a/_data/map_data.json
+++ b/_data/map_data.json
@@ -83,5 +83,18 @@
       "PyCon Zimbabwe": [2024]
     }
   },
-  "BRA": { "Members in this country": true }
+  "BRA": { "Members in this country": true },
+  "CAN": { "Name": "Canada", "Members in this country": true },
+  "DEU": { "Name": "Germany", "Members in this country": true },
+  "GBR": { "Name": "United Kingdom", "Members in this country": true },
+  "FRA": { "Name": "France", "Members in this country": true },
+  "IRL": { "Name": "Ireland", "Members in this country": true },
+  "ESP": { "Name": "Spain", "Members in this country": true },
+  "MAR": { "Name": "Morocco", "Members in this country": true },
+  "EGY": { "Name": "Egypt", "Members in this country": true },
+  "KEN": { "Name": "Kenya", "Members in this country": true },
+  "ETH": { "Name": "Ethiopia", "Members in this country": true },
+  "SSD": { "Name": "South Sudan", "Members in this country": true },
+  "MDG": { "Name": "Madagascar", "Members in this country": true },
+  "MOZ": { "Name": "Mozambique", "Members in this country": true }
 }

--- a/scripts/map.py
+++ b/scripts/map.py
@@ -123,6 +123,8 @@ def generate_map():
     for feature in geojson_data["features"]:
         props = feature["properties"]
         iso = props.get("ISO_A3")
+        if iso == "-99":
+            iso = props.get("ISO_A3_EH", iso)
 
         if iso in map_data:
             name = props.get("NAME", iso)


### PR DESCRIPTION
## Summary
- Add 13 countries with BPD members to the map: Canada, Germany, UK, France, Ireland, Spain, Morocco, Egypt, Kenya, Ethiopia, South Sudan, Madagascar, Mozambique
- Fix `ISO_A3` fallback to `ISO_A3_EH` in map script for countries where Natural Earth GeoJSON uses `"-99"` as a placeholder (e.g. France)

Closes #872

## Test plan
- [ ] Verify the map renders all 26 countries on the about page
- [ ] Confirm France appears correctly (was previously unmatchable due to GeoJSON quirk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)