### PR TITLE
Add Jay Miller to 2026 foundational supporters

### DIFF
--- a/_data/foundational_supporters.json
+++ b/_data/foundational_supporters.json
@@ -1,5 +1,5 @@
 {
-  "2026": ["Sarah Drasner"],
+  "2026": ["Sarah Drasner", "Jay Miller"],
   "2025": [
     "Albert Sweigart",
     "Alla Barbalat",


### PR DESCRIPTION
## Summary
- Adds Jay Miller to the 2026 foundational supporters list in `_data/foundational_supporters.json`

**Note:** All work on this PR was performed by Claude (Opus 4.6).

Closes #877

## Test plan
- [ ] Verify the site renders the 2026 supporters list with Jay Miller included

🤖 Generated with [Claude Code](https://claude.com/claude-code)