### PR TITLE
Fix community.html 404 with redirect to about page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Below are some diagrams to best explain the file structure of the website, the d
 
 ## Website structure
 
-The diagram below illustrates the main navigation structure of BPD website, showing how the homepage `(Index)` connects to various sections, including the `Home`, `Blog`, `About Us`, `Events`, and `Community`. Each blog article, represented as `Article1` and `Article2`, is linked directly from the `Blog` section.
+The diagram below illustrates the main navigation structure of BPD website, showing how the homepage `(Index)` connects to various sections, including the `Home`, `Blog`, `About Us`, `Events`, and `Support Us`. Each blog article, represented as `Article1` and `Article2`, is linked directly from the `Blog` section.
 
 ```
 Website Structure:
@@ -24,8 +24,7 @@ Index/
 ├── About Us
 ├── Events
 ├── Sponsored Events
-├── Community
-└── Sponsor Us
+└── Support Us
 ```
 
 ## Development structure

--- a/app.py
+++ b/app.py
@@ -69,6 +69,11 @@ class Index(Page):
 
 
 @app.page
+class Community(Page):
+    content_path = "community.html"
+
+
+@app.page
 class About(Page):
     template = "about.html"
     data = json.loads(pathlib.Path("_data/leadership.json").read_text())

--- a/community.html
+++ b/community.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="refresh" content="0; url=/about.html#join-the-community" />
+    <title>Redirecting to Community</title>
+  </head>
+  <body>
+    <p>Redirecting to <a href="/about.html#join-the-community">Community</a>...</p>
+  </body>
+</html>

--- a/tests/test.py
+++ b/tests/test.py
@@ -106,6 +106,16 @@ def test_mailto_bpdevs(built_site: pathlib.Path) -> None:
     ), "Expected mailto:contact@blackpythondevs.com link not found"
 
 
+def test_community_redirects_to_about(built_site: pathlib.Path) -> None:
+    """Check that community.html contains a redirect to the about page."""
+    community = built_site / "community.html"
+    assert community.exists(), "community.html should exist in build output"
+    content = community.read_text()
+    assert (
+        "/about.html#join-the-community" in content
+    ), "community.html should redirect to /about.html#join-the-community"
+
+
 def _blog_post_files() -> list[pathlib.Path]:
     """Get all blog post HTML files (excluding index and pagination pages)."""
     blog_dir = OUTPUT_DIR / "blog"


### PR DESCRIPTION
## Issue Link 🔗:

Closes #889

## Type of Change

- [x] Bug fix 🐞
- [ ] New feature/page
- [ ] Documentation update
- [ ] Other

## Description 📋

- **What:** The `/community.html` page returns a 404 because it was removed in a previous refactor when community content was merged into the about page. QR codes on physical cards (e.g., handed out at PyTexas) still point to this URL.

- **Why:** Users scanning the QR code hit a dead link instead of reaching the community info.

- **How:** Adds a `community.html` page with a `<meta http-equiv="refresh">` redirect that immediately sends visitors to `/about.html#join-the-community`. The page is registered in `app.py` so Render Engine includes it in the build output.

## Checklist ✅

- [x] Followed the [Code of Conduct](https://github.com/BlackPythonDevs/blackpythondevs.github.io?tab=coc-ov-file) and [Contribution Guide](https://github.com/BlackPythonDevs/blackpythondevs.github.io/blob/469afd71943738b7209bfe56d5a4e35394fbaafc/CONTRIBUTING.md)
- [x] Ran `pre-commit run --all`
- [x] All tests pass locally
- [x] Added tests (if applicable)
- [x] Documentation updated (if applicable)

## Additional Notes & Screenshots

- Added a test (`test_community_redirects_to_about`) verifying the redirect exists in the build output
- Updated the CONTRIBUTING.md navigation diagram to remove the stale "Community" entry

Note: All work on this PR was performed by Claude Opus 4.6