### PR TITLE
Fix partnerships.html 404 with redirect and update footer link

### DIFF
--- a/_layouts/_includes/footer.html
+++ b/_layouts/_includes/footer.html
@@ -12,7 +12,7 @@
         <ul>
           <li><a href="/about.html">About Us</a></li>
           <li><a href="/events.html">Events</a></li>
-          <li><a href="/partnerships.html">Partnerships</a></li>
+          <li><a href="/support.html#partnerships">Partnerships</a></li>
           <li><a href="/about.html#join-the-community">Community</a></li>
           <li><a href="/support.html">Support</a></li>
           <li><a href="/code-of-conduct.html">Code of Conduct</a></li>

--- a/app.py
+++ b/app.py
@@ -69,6 +69,11 @@ class Index(Page):
 
 
 @app.page
+class Partnerships(Page):
+    content_path = "partnerships.html"
+
+
+@app.page
 class About(Page):
     template = "about.html"
     data = json.loads(pathlib.Path("_data/leadership.json").read_text())

--- a/partnerships.html
+++ b/partnerships.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="refresh" content="0; url=/support.html#partnerships" />
+    <title>Redirecting to Partnerships</title>
+  </head>
+  <body>
+    <p>
+      Redirecting to
+      <a href="/support.html#partnerships">Partnerships</a>...
+    </p>
+  </body>
+</html>

--- a/tests/test.py
+++ b/tests/test.py
@@ -106,6 +106,16 @@ def test_mailto_bpdevs(built_site: pathlib.Path) -> None:
     ), "Expected mailto:contact@blackpythondevs.com link not found"
 
 
+def test_partnerships_redirects_to_support(built_site: pathlib.Path) -> None:
+    """Check that partnerships.html contains a redirect to the support page."""
+    partnerships = built_site / "partnerships.html"
+    assert partnerships.exists(), "partnerships.html should exist in build output"
+    content = partnerships.read_text()
+    assert (
+        "/support.html#partnerships" in content
+    ), "partnerships.html should redirect to /support.html#partnerships"
+
+
 def _blog_post_files() -> list[pathlib.Path]:
     """Get all blog post HTML files (excluding index and pagination pages)."""
     blog_dir = OUTPUT_DIR / "blog"


### PR DESCRIPTION
## Issue Link 🔗:

Closes #891

## Type of Change

- [x] Bug fix 🐞
- [ ] New feature/page
- [ ] Documentation update
- [ ] Other

## Description 📋

- **What:** The `/partnerships.html` page returns a 404 because it was merged into the support page. The footer "Partnerships" link still points to the dead URL.

- **Why:** Anyone clicking "Partnerships" in the footer hits a 404 instead of reaching the partnerships section.

- **How:** Updates the footer link to point to `/support.html#partnerships` and adds a `partnerships.html` redirect page (meta-refresh) for any external links still pointing to the old URL. The redirect page is registered in `app.py` so Render Engine includes it in the build output.

## Checklist ✅

- [x] Followed the [Code of Conduct](https://github.com/BlackPythonDevs/blackpythondevs.github.io?tab=coc-ov-file) and [Contribution Guide](https://github.com/BlackPythonDevs/blackpythondevs.github.io/blob/469afd71943738b7209bfe56d5a4e35394fbaafc/CONTRIBUTING.md)
- [x] Ran `pre-commit run --all`
- [x] All tests pass locally
- [x] Added tests (if applicable)
- [x] Documentation updated (if applicable)

## Additional Notes & Screenshots

- Added `test_partnerships_redirects_to_support` test verifying the redirect exists in the build output
- Confirmed `/partnerships.html` returns 404 on the live site

Note: All work on this PR was performed by Claude Opus 4.6