### PR TITLE
Close CFP on Leadership Summit 2026 page

### DIFF
--- a/events/leadership-summit-2026-ohio.md
+++ b/events/leadership-summit-2026-ohio.md
@@ -13,7 +13,6 @@ We are happy to announce the 2026 Black Python Devs Leadership Summit on **July 
 
 This is done in partnership with the [PyOhio Organization](https://www.pyohio.org/2026/) that Black Python Devs has been proud to support for several years.
 
-<a role="button" href="https://pretalx.com/pyohio-2026/submit/?track=6985-black-python-devs-leadership-summit">Submit Talk Today!</a>
 <a role="button" class="secondary" href="https://pyohio.org/2026">Learn More About PyOhio</a>
 
 ## Who is invited?
@@ -28,52 +27,9 @@ Anyone in leadership or wanting to get into leadership at the local, regional, o
 
 ## Is there a CFP
 
-For the first time we're opening up the afternoon sessions to selected speakers from a Call for Papers (CFP). We hope to bring presentations from folks all over to energize and inform today's and tomorrow's Leaders of the Python Community.
+For the first time we opened up the afternoon sessions to selected speakers from a Call for Papers (CFP). We hope to bring presentations from folks all over to energize and inform today's and tomorrow's Leaders of the Python Community.
 
-The [CFP is currently open](https://pretalx.com/pyohio-2026/submit/?track=6985-black-python-devs-leadership-summit). Set the track to _Black Python Devs Leadership Summit_. Talk should be 20 minutes with Q&A.
-
-The CFP closes on 2026-04-20 08:00 (America/New_York).
-
-<div id="cfp-countdown" style="text-align:center; margin: 1.5rem 0; padding: 1.5rem; border: 1px solid var(--pico-card-border-color); border-radius: var(--pico-border-radius); background: var(--pico-card-background-color); box-shadow: var(--pico-box-shadow);">
-  <p id="countdown-text" style="font-size: 1.25rem; font-weight: bold;"></p>
-  <a role="button" href="https://pretalx.com/pyohio-2026/submit/?track=6985-black-python-devs-leadership-summit">Submit to the CFP</a>
-</div>
-
-<script>
-(function() {
-  const deadline = new Date("2026-04-20T08:00:00-04:00");
-  const el = document.getElementById("countdown-text");
-  const container = document.getElementById("cfp-countdown");
-
-  function update() {
-    const now = new Date();
-    const diff = deadline - now;
-    if (diff <= 0) {
-      el.textContent = "The CFP is now closed.";
-      const btn = container.querySelector("a[role='button']");
-      if (btn) { btn.setAttribute("disabled", ""); btn.removeAttribute("href"); }
-      return;
-    }
-    const days = Math.floor(diff / 86400000);
-    const hours = Math.floor((diff % 86400000) / 3600000);
-    const minutes = Math.floor((diff % 3600000) / 60000);
-    const seconds = Math.floor((diff % 60000) / 1000);
-    el.textContent = days + "d " + hours + "h " + minutes + "m " + seconds + "s until CFP closes";
-    requestAnimationFrame(update);
-  }
-  update();
-})();
-</script>
-
-We're looking for submissions around the following:
-
-- serving as a leader in a regional or global tech community
-- organizing a meetup, workshop, or conference
-- event planning
-- open source leadership
-- community engagement
-- fundraising
-- surprise us!
+**The CFP is now closed.** Thank you to everyone who submitted. Selected speakers will be notified and announced on this page.
 
 ## Is there speaker reimbursement?
 


### PR DESCRIPTION
## Summary
- CFP for the BPD Leadership Summit 2026 is closed as of 2026-04-20
- Removed the "Submit Talk Today!" button, the CFP-open copy, and the countdown widget
- Replaced with a note that the CFP is now closed

Closes #894

## Test plan
- [ ] Verify `events/leadership-summit-2026-ohio.md` renders with the closed-CFP messaging
- [ ] Confirm no remaining links prompting submissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)