### PR TITLE
Add add-conference workflow script

### DIFF
--- a/justfile
+++ b/justfile
@@ -38,6 +38,11 @@ test:
 test-verbose:
     uv run --dev pytest -v
 
+# Add a sponsored conference and regenerate the activity map
+# Usage: just add-conference --title "PyCon Brazil" --year 2026 --continent "South America" --country "Brazil"
+add-conference *ARGS:
+    uv run python scripts/add_conference.py {{ARGS}}
+
 # Run full development workflow
 dev: sync lint test build
     @echo "✓ Development workflow complete"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,8 @@ dependencies = [
     "render-engine[cli]>=2026.3.4a2",
     "pyyaml",
     "folium>=0.20.0",
+    "click",
+    "pycountry",
 ]
 
 [dependency-groups]

--- a/scripts/add_conference.py
+++ b/scripts/add_conference.py
@@ -1,0 +1,112 @@
+"""
+Add a sponsored conference to the events data and regenerate the activity map.
+
+Updates:
+1. _data/sponsored_events.json — appends the conference under sponsored.<year>.<continent>
+2. _data/map_data.json — adds/updates the country entry with the conference and year
+3. assets/map.html — regenerates via scripts/map.py
+
+Usage:
+    uv run python scripts/add_conference.py \\
+        --title "PyCon Brazil" \\
+        --year 2026 \\
+        --continent "South America" \\
+        --country "Brazil"
+
+The ISO_A3 country code is resolved from --country via pycountry.
+"""
+
+import json
+from pathlib import Path
+
+import click
+import pycountry
+
+from map import generate_map
+
+ROOT = Path(__file__).resolve().parent.parent
+SPONSORED_JSON = ROOT / "_data" / "sponsored_events.json"
+MAP_JSON = ROOT / "_data" / "map_data.json"
+
+CONTINENTS = [
+    "Africa",
+    "Antarctica",
+    "Asia",
+    "Europe",
+    "North America",
+    "Oceania",
+    "South America",
+]
+
+
+def update_sponsored_events(title: str, year: int, continent: str) -> None:
+    data = json.loads(SPONSORED_JSON.read_text())
+    year_key = str(year)
+    sponsored = data.setdefault("sponsored", {})
+    year_bucket = sponsored.setdefault(year_key, {})
+    continent_list = year_bucket.setdefault(continent, [])
+    if title in continent_list:
+        click.echo(
+            f"  sponsored_events.json: '{title}' already listed for {continent} {year_key}"
+        )
+    else:
+        continent_list.append(title)
+        click.echo(
+            f"  sponsored_events.json: added '{title}' to {continent} {year_key}"
+        )
+    SPONSORED_JSON.write_text(json.dumps(data, indent=2) + "\n")
+
+
+def resolve_country(country: str) -> tuple[str, str]:
+    """Return (ISO_A3, canonical_name) for a country name, using fuzzy matching."""
+    try:
+        matches = pycountry.countries.search_fuzzy(country)
+    except LookupError as exc:
+        raise click.ClickException(f"Could not resolve country '{country}'.") from exc
+    match = matches[0]
+    name = getattr(match, "common_name", match.name)
+    return match.alpha_3, name
+
+
+def update_map_data(title: str, year: int, iso: str, country: str) -> None:
+    data = json.loads(MAP_JSON.read_text())
+    entry = data.setdefault(iso, {})
+    entry["Name"] = country
+    sponsored = entry.setdefault("Sponsored", {})
+    years = sponsored.setdefault(title, [])
+    if year in years:
+        click.echo(f"  map_data.json: '{title}' already has year {year} for {iso}")
+    else:
+        years.append(year)
+        years.sort()
+        click.echo(f"  map_data.json: added {year} to '{title}' under {iso}")
+    MAP_JSON.write_text(json.dumps(data, indent=2) + "\n")
+
+
+@click.command(help="Add a sponsored conference and regenerate the activity map.")
+@click.option("--title", required=True, help="Conference title.")
+@click.option("--year", type=int, required=True, help="Year sponsored.")
+@click.option(
+    "--continent",
+    required=True,
+    type=click.Choice(CONTINENTS, case_sensitive=False),
+    help="Continent grouping for sponsored_events.json.",
+)
+@click.option(
+    "--country",
+    required=True,
+    help="Country name (fuzzy-matched to ISO_A3 via pycountry).",
+)
+def main(title: str, year: int, continent: str, country: str) -> None:
+    iso, canonical = resolve_country(country)
+    click.echo(f"Resolved '{country}' → {canonical} ({iso})")
+    click.echo(f"Adding '{title}' ({year}, {continent}, {iso})")
+    update_sponsored_events(title, year, continent)
+    update_map_data(title, year, iso, canonical)
+    click.echo("Regenerating assets/map.html ...")
+    generate_map()
+    click.echo("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -50,7 +50,9 @@ name = "blackpythondevs-site"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "click" },
     { name = "folium" },
+    { name = "pycountry" },
     { name = "pyyaml" },
     { name = "render-engine", extra = ["cli"] },
 ]
@@ -67,7 +69,9 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "click" },
     { name = "folium", specifier = ">=0.20.0" },
+    { name = "pycountry" },
     { name = "pyyaml" },
     { name = "render-engine", extras = ["cli"], specifier = ">=2026.3.4a2" },
 ]
@@ -473,6 +477,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232, upload-time = "2025-12-16T21:14:33.552Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77", size = 226437, upload-time = "2025-12-16T21:14:32.409Z" },
+]
+
+[[package]]
+name = "pycountry"
+version = "26.2.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/1d/061b9e7a48b85cfd69f33c33d2ef784a531c359399ad764243399673c8f5/pycountry-26.2.16.tar.gz", hash = "sha256:5b6027d453fcd6060112b951dd010f01f168b51b4bf8a1f1fc8c95c8d94a0801", size = 7711342, upload-time = "2026-02-17T03:42:52.367Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/42/7703bd45b62fecd44cd7d3495423097e2f7d28bc2e99e7c1af68892ab157/pycountry-26.2.16-py3-none-any.whl", hash = "sha256:115c4baf7cceaa30f59a4694d79483c9167dbce7a9de4d3d571c5f3ea77c305a", size = 8044600, upload-time = "2026-02-17T03:42:49.777Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- New `just add-conference` recipe runs `scripts/add_conference.py`, a Click CLI that appends a sponsored conference to `_data/sponsored_events.json`, updates `_data/map_data.json`, and regenerates `assets/map.html`.
- Country names are fuzzy-resolved to ISO_A3 via `pycountry`, so callers only supply `--title`, `--year`, `--continent`, and `--country`.
- Adds `click` and `pycountry` to project dependencies.

## Test plan
- [ ] `just add-conference --title "PyCon Brazil" --year 2026 --continent "South America" --country "Brazil"` updates both JSON files and regenerates the map
- [ ] Re-running the same command is idempotent (no duplicate entries)
- [ ] `uv run python scripts/add_conference.py --help` shows expected options

🤖 Generated with [Claude Code](https://claude.com/claude-code)