### PR TITLE
Add runbooks for common website maintenance tasks

### DIFF
--- a/runbooks/README.md
+++ b/runbooks/README.md
@@ -1,0 +1,25 @@
+# Runbooks
+
+Step-by-step guides for common maintenance tasks on `blackpythondevs.github.io`,
+derived from the merged PRs of the last ~12 months.
+
+| Task                               | Runbook                                                        | Example PRs            |
+| ---------------------------------- | -------------------------------------------------------------- | ---------------------- |
+| Add a foundational supporter       | [add-foundational-supporter.md](add-foundational-supporter.md) | #893, #879, #870       |
+| Add a corporate sponsor            | [add-corporate-sponsor.md](add-corporate-sponsor.md)           | #888, #866             |
+| Add a BPD Council member           | [add-council-member.md](add-council-member.md)                 | #853, #851, #849       |
+| Publish a blog post / announcement | [publish-blog-post.md](publish-blog-post.md)                   | #888, #864             |
+| Add or update a sponsored event    | [add-sponsored-event.md](add-sponsored-event.md)               | #863, #854             |
+| Fix a broken link or 404           | [fix-broken-link.md](fix-broken-link.md)                       | #892, #890, #856       |
+| Update site navigation             | [update-navigation.md](update-navigation.md)                   | #844, #840, #830, #829 |
+
+## Before you start
+
+Every runbook assumes:
+
+1. You have cloned the repo and installed dependencies: `just sync`
+2. You branch from `gh-pages` (the default branch) and open a PR back to `gh-pages`.
+3. You run `just pre-commit` and `just test` before pushing.
+4. You preview locally with `just serve` (render-engine dev server).
+
+See `CONTRIBUTING.md` and `MAINTAINERS.md` for repository-wide conventions.

--- a/runbooks/add-corporate-sponsor.md
+++ b/runbooks/add-corporate-sponsor.md
@@ -1,0 +1,51 @@
+# Add a Corporate Sponsor
+
+Corporate sponsors appear in the Corporate Sponsors grid on the homepage and
+get an announcement blog post.
+
+**Reference PRs:** #888 (JetBrains), #866 (Anaconda), #864 (Anaconda announcement)
+
+## Inputs you need
+
+- Sponsor name
+- Logo file (prefer `.webp`; `.png` acceptable for legacy assets)
+- Sponsorship blurb / announcement text
+- A featured banner image for the blog post (1200×630 recommended)
+
+## Steps
+
+1. **Add the logo asset**
+
+   - Place the logo in `assets/images/` — e.g. `assets/images/jetbrains.webp`.
+   - Use a transparent background where possible so it works on the site theme.
+
+2. **Add the sponsor to the grid**
+
+   - Edit `_layouts/_includes/sponsors.html`.
+   - Under `<h3>Corporate Sponsors</h3>` add a new `<article class="sponsor">`
+     with an `<img>` pointing at the new asset. Keep `style="height: 2rem"` to
+     match the other logos.
+
+3. **Write the announcement post**
+
+   - Create `_posts/YYYY-MM-DD-<sponsor>-corporate-sponsorship.md`.
+   - Frontmatter needs: `author`, `date`, `description`, `featured_image`, `title`.
+   - Add the featured image (e.g. `assets/images/corporate-sponsorship-<sponsor>.webp`).
+   - Pattern the body after `_posts/2026-04-16-jetbrains-corporate-sponsorship.md`.
+
+4. **Run checks**
+
+   - `just pre-commit`
+   - `just test`
+   - `just serve` → confirm the logo shows on the homepage and the post renders.
+
+5. **Open a PR** titled `Add <Sponsor> as corporate sponsor`. Reference any
+   intake/coordination issues that tracked the sponsorship.
+
+## Gotchas
+
+- Logo height must match the existing `2rem` inline style so the grid doesn't
+  jitter. Do not introduce a new CSS class just for one sponsor.
+- If you also need to remove a prior sponsor, do it in the same PR so the
+  grid stays coherent.
+- Large PNGs should be converted to `.webp` before committing.

--- a/runbooks/add-council-member.md
+++ b/runbooks/add-council-member.md
@@ -1,0 +1,58 @@
+# Add a BPD Council Member
+
+Adding a Council member requires three coordinated changes: data, image asset,
+and an announcement post.
+
+**Reference PRs:** #853 (Ariane), #851 (Edmond), #849 (Israel)
+
+## Recommended: use the script
+
+`scripts/add_council_member.py` automates all three steps:
+
+```bash
+uv run python scripts/add_council_member.py \
+    --name "First Last" \
+    --image /path/to/photo.webp \
+    --bio "Their bio text here..." \
+    --linkedin "https://linkedin.com/in/..." \
+    --date 2026-04-20
+```
+
+The script:
+
+1. Adds the name to the `Council` list in `_data/leadership.json`.
+2. Copies/converts the image to `assets/images/<slug>-council.webp` (requires
+   `magick` / ImageMagick if the source is not already `.webp`).
+3. Creates `_posts/YYYY-MM-DD-<slug>-added-to-bpd-council.md`.
+
+Review the generated diff, add a banner image if desired (see below), then
+`just pre-commit` / `just test` / open a PR.
+
+## Manual fallback
+
+If you can't run the script:
+
+1. **Leadership data** — Edit `_data/leadership.json` and append to the
+   `Council` array. Required fields: `name`, `image`, `alt`, `title` (use
+   `"Council"` unless the person has a specific role). Optional: `linkedin`.
+2. **Image** — Add `assets/images/<slug>-council.webp`. 512×512 square works
+   well. Convert non-webp sources with `magick input.png output.webp`.
+3. **(Optional) banner image** — Some announcements include a wider social
+   banner at `assets/images/banner_<firstname>.webp` (see PR #853, #852).
+4. **Post** — Create `_posts/YYYY-MM-DD-<slug>-added-to-bpd-council.md` with
+   frontmatter matching existing council posts. Reference one of the recent
+   ones like `2026-02-13-edmond-makolle-added-to-bpd-council.md` for the
+   exact shape.
+
+## Checks
+
+- `just pre-commit`
+- `just test` — the author list check in `scripts/check_author_list.py` will
+  fail if the new member authors a post but isn't listed in `_data/authors.json`.
+  Council members are the _subject_, not the author, so this rarely triggers.
+- `just serve` → confirm the About page grid renders the new card.
+
+## PR conventions
+
+- Title: `Add <Name> to BPD Council`
+- Link the intake issue for the member in the PR body.

--- a/runbooks/add-foundational-supporter.md
+++ b/runbooks/add-foundational-supporter.md
@@ -1,0 +1,29 @@
+# Add a Foundational Supporter
+
+Foundational Supporters are individuals who financially back BPD for a given
+calendar year. They render on the Support page from `_data/foundational_supporters.json`.
+
+**Reference PRs:** #893 (Carol Willing), #879 (Jay Miller), #870 (Sarah Drasner)
+
+## Steps
+
+1. Open `_data/foundational_supporters.json`.
+2. Find the entry for the current year (e.g. `"2026": [...]`). If it does not
+   yet exist, add a new top-level key for the year with an empty array.
+3. Add the supporter's full name to the array. Keep the array alphabetically
+   sorted by first name to match existing convention.
+4. Save. No other files need to change — the `foundational_supporters` include
+   renders directly from this JSON.
+5. Run `just test` to confirm JSON is valid and site builds.
+6. Commit with a message like `Add <Name> to <year> foundational supporters`
+   and open a PR.
+
+## Verification
+
+- `just serve` → visit `/support` and confirm the name renders in the right year.
+- No image asset is needed for foundational supporters.
+
+## Gotchas
+
+- Do not reorder prior years' lists; only touch the current year.
+- Names are rendered verbatim — match the spelling/capitalization the supporter requests.

--- a/runbooks/add-sponsored-event.md
+++ b/runbooks/add-sponsored-event.md
@@ -1,0 +1,47 @@
+# Add or Update a Sponsored Event
+
+Sponsored events are listed on the homepage and the About page, rendered from
+`_data/sponsored_events.json`.
+
+**Reference PRs:** #863 (2026 update), #854 (typo fix)
+
+## Data shape
+
+`_data/sponsored_events.json` has two top-level keys:
+
+- `bpd` — list of BPD-owned events (objects with `title` + `url` pointing at
+  a page under `/bpd-events/`).
+- `sponsored` — dict keyed by year, then by region (Africa, North America,
+  South America, …), each a list of event-name strings.
+
+## Add a sponsored event
+
+1. Open `_data/sponsored_events.json`.
+2. Find the current year and the region.
+3. Append the event name. If the region doesn't exist for that year yet, add it.
+4. If it's the first event of a new year, add the year key with region sub-keys.
+
+Event names are plain strings — no URL is rendered. If you want a linked page,
+use the `bpd` list instead and create the corresponding event page under
+`events/` (e.g. `events/leadership-summit-2026-ohio.md`).
+
+## Add a BPD-owned event
+
+1. Create the event markdown at `events/<slug>.md`. Reference existing ones
+   like `events/leadership-summit-2026-ohio.md` for frontmatter.
+2. Add an entry to the `bpd` array in `sponsored_events.json`:
+   ```json
+   { "title": "<Event Title>", "url": "/bpd-events/<slug>.html" }
+   ```
+
+## Checks
+
+- `just test` — validates JSON.
+- `just serve` — confirm the event appears in the sponsored-events include on
+  the homepage / About page.
+
+## Gotchas
+
+- Don't re-order historical years; only edit the year you're changing.
+- Event name strings must match whatever is publicly promoted — these are
+  shown verbatim.

--- a/runbooks/fix-broken-link.md
+++ b/runbooks/fix-broken-link.md
@@ -1,0 +1,56 @@
+# Fix a Broken Link or 404
+
+Broken links break search rankings and trust. The recent fixes followed one
+of two patterns: update the link in the template, or create a redirect stub.
+
+**Reference PRs:** #892 (partnerships 404), #890 (community 404), #856
+(broken events links)
+
+## Triage
+
+1. Reproduce the 404. Note the exact URL.
+2. Decide:
+   - **Link is wrong** → fix the href in the template.
+   - **Old URL is indexed / linked externally** → create a redirect stub so
+     existing links keep working.
+
+## Pattern A — fix the link in the template
+
+1. Grep for the broken URL:
+   ```bash
+   rg "old-url" _layouts/ *.html pages/ _posts/
+   ```
+2. Update the `href` to the correct target.
+3. If the link was in `_layouts/_includes/footer.html` or `header.html`, also
+   check that nav items in `app.py` still agree.
+4. Add a test in `tests/test.py` asserting the new path returns the right
+   status (the existing tests use render-engine's build output — mirror them).
+
+## Pattern B — add a redirect stub
+
+Used when an old top-level page (e.g. `community.html`, `partnerships.html`)
+was merged into another page but external links still hit the old URL.
+
+1. Create an HTML file at the old path (e.g. `community.html`) at the repo root.
+   Use a meta refresh or a short script; see the existing `community.html` and
+   `partnerships.html` for the exact shape.
+2. Register the page in `app.py`:
+   ```python
+   @app.page
+   class Community(Page):
+       content_path = "community.html"
+   ```
+3. Add the old→new mapping to `redirects.json` so the pattern stays documented.
+4. Update any internal links (footer, header, CONTRIBUTING) to point at the
+   new canonical URL rather than the redirect.
+5. Extend `tests/test.py` to assert the redirect page exists in the build output.
+
+## Checks
+
+- `just build` and inspect `output/` to confirm the page/redirect is there.
+- `just test` for the new assertion.
+- Click through the link in `just serve`.
+
+## PR title
+
+`Fix <page>.html 404 with redirect` or `Fix broken <area> links`.

--- a/runbooks/publish-blog-post.md
+++ b/runbooks/publish-blog-post.md
@@ -1,0 +1,55 @@
+# Publish a Blog Post / Announcement
+
+Blog posts live in `_posts/` and are rendered under `/news/` (formerly `/blog/`).
+
+**Reference PRs:** #888 (sponsor announcement), #864 (Anaconda announcement),
+plus all council-member posts.
+
+## Filename
+
+`_posts/YYYY-MM-DD-<kebab-case-slug>.md`
+
+The date must be correct — render-engine uses it for ordering and feed dates.
+
+## Frontmatter
+
+Minimum fields, based on recent posts:
+
+```markdown
+---
+author:
+  - Jay Miller
+date: 2026-04-16
+description: One-line summary used for SEO and the post list preview.
+featured_image: /assets/images/<post-image>.webp
+title: Human-readable post title
+---
+```
+
+- `author` is a list; each entry must match a `name` in `_data/authors.json`.
+  If the author isn't there yet, add them (see "Adding an author" below).
+- `featured_image` is optional but recommended for share previews.
+- Do **not** include `layout:` — the default post layout is applied automatically.
+
+## Adding an author
+
+Edit `_data/authors.json` and append an object with at least `name` and `bio`.
+Add `bpd_role` and `social` links if known. `scripts/check_author_list.py`
+runs under `just test` and will fail the build if a post references an
+unknown author.
+
+## Body
+
+Standard Markdown. Images referenced in the body go in `assets/images/` and
+are linked with absolute paths (e.g. `![alt](/assets/images/foo.webp)`).
+
+## Checks
+
+- `just pre-commit` — runs frontmatter and formatting checks.
+- `just test` — includes the author-list check.
+- `just serve` — confirm the post shows on `/news/` and its featured image renders.
+
+## PR title
+
+Short and descriptive, e.g. `Add JetBrains corporate sponsorship post` or
+`Publish 2024 recap`.

--- a/runbooks/update-navigation.md
+++ b/runbooks/update-navigation.md
@@ -1,0 +1,51 @@
+# Update Site Navigation
+
+The main nav is driven by the `navigation` list at the top of `app.py`. Header
+and footer templates read `site_vars["navigation"]` and render links from it.
+
+**Reference PRs:** #844 (remove BPD Events + Sponsored Events from header),
+#840 (remove Community from header), #830 (remove Home), #829 (rename Blog → News),
+#832 (combine Events links), #831 (combine Discounts + Support)
+
+## Rename a nav item
+
+1. In `app.py`, edit the `text` field of the matching entry in `navigation`.
+2. If the rename also changes the URL (e.g. `/blog/` → `/news/`), update `url`
+   too and add a redirect for the old path (see `fix-broken-link.md`).
+3. Search the codebase for hard-coded references to the old label in footer,
+   CONTRIBUTING, and posts — update where user-visible.
+
+## Remove a nav item
+
+1. Delete the entry from `navigation` in `app.py`.
+2. Remove any footer/header references to the page (e.g. `_layouts/_includes/footer.html`).
+3. If the page still exists and is linked externally, leave the page file but
+   remove it from nav. If the page itself is being retired, add a redirect
+   (see `fix-broken-link.md`).
+4. Update tests in `tests/test.py` that asserted the old nav entry existed.
+
+## Add a nav item
+
+1. Append a new object to `navigation`:
+   ```python
+   {"text": "<Label>", "url": "/<path>.html", "icon": "iconoir-<name>"}
+   ```
+2. Icons come from the Iconoir set — pick one consistent with the existing
+   entries.
+3. Ensure the target URL resolves in the built site.
+
+## Combine pages
+
+Pattern used for Events (#832) and Support (#831):
+
+1. Decide the canonical destination page.
+2. Move the content from the sibling page into it.
+3. Remove the sibling `@app.page` class from `app.py`.
+4. Add a redirect stub for the retired URL.
+5. Update the `navigation` list so there's a single entry.
+
+## Checks
+
+- `just build` — verify the nav renders in the generated output.
+- `just test` — update/add assertions about the nav.
+- `just serve` — click every nav entry and confirm none 404.


### PR DESCRIPTION
## Summary
- Adds a new `runbooks/` directory with step-by-step guides for the most frequent site-maintenance tasks seen in PRs over the last ~12 months.
- Covers: foundational supporters, corporate sponsors, council members, blog posts, sponsored events, broken-link fixes, and site-navigation updates.
- Each runbook references concrete example PRs so future contributors can see the pattern in practice.

## Test plan
- [ ] Review `runbooks/README.md` index table renders correctly on GitHub
- [ ] Spot-check one runbook against a recent matching PR (e.g. `add-corporate-sponsor.md` vs #888)
- [ ] Confirm `just pre-commit` passes (already passed locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)