### PR TITLE
Add 2026 sponsored events and community-sponsorship disclaimer

### DIFF
--- a/_data/map_data.json
+++ b/_data/map_data.json
@@ -23,7 +23,8 @@
     "Sponsored": {
       "PyHo - Ghana": [2024],
       "Django Girls - Koforidua": [2025],
-      "Django Girls - Ho": [2025]
+      "Django Girls - Ho": [2025],
+      "Django Girls - Tamale": [2026]
     }
   },
   "NAM": {
@@ -61,7 +62,7 @@
   "USA": {
     "Name": "United States",
     "Sponsored": {
-      "PyTexas": [2024],
+      "PyTexas": [2024, 2026],
       "PyOhio": [2024, 2025],
       "PyTexas Foundation": [2025],
       "PyBeach": [2025],
@@ -83,18 +84,71 @@
       "PyCon Zimbabwe": [2024]
     }
   },
-  "BRA": { "Members in this country": true },
-  "CAN": { "Name": "Canada", "Members in this country": true },
-  "DEU": { "Name": "Germany", "Members in this country": true },
-  "GBR": { "Name": "United Kingdom", "Members in this country": true },
-  "FRA": { "Name": "France", "Members in this country": true },
-  "IRL": { "Name": "Ireland", "Members in this country": true },
-  "ESP": { "Name": "Spain", "Members in this country": true },
-  "MAR": { "Name": "Morocco", "Members in this country": true },
-  "EGY": { "Name": "Egypt", "Members in this country": true },
-  "KEN": { "Name": "Kenya", "Members in this country": true },
-  "ETH": { "Name": "Ethiopia", "Members in this country": true },
-  "SSD": { "Name": "South Sudan", "Members in this country": true },
-  "MDG": { "Name": "Madagascar", "Members in this country": true },
-  "MOZ": { "Name": "Mozambique", "Members in this country": true }
+  "BRA": {
+    "Members in this country": true
+  },
+  "CAN": {
+    "Name": "Canada",
+    "Members in this country": true,
+    "Sponsored": {
+      "PyNorth Meetups": [2026]
+    }
+  },
+  "DEU": {
+    "Name": "Germany",
+    "Members in this country": true
+  },
+  "GBR": {
+    "Name": "United Kingdom",
+    "Members in this country": true
+  },
+  "FRA": {
+    "Name": "France",
+    "Members in this country": true
+  },
+  "IRL": {
+    "Name": "Ireland",
+    "Members in this country": true
+  },
+  "ESP": {
+    "Name": "Spain",
+    "Members in this country": true
+  },
+  "MAR": {
+    "Name": "Morocco",
+    "Members in this country": true
+  },
+  "EGY": {
+    "Name": "Egypt",
+    "Members in this country": true
+  },
+  "KEN": {
+    "Name": "Kenya",
+    "Members in this country": true,
+    "Sponsored": {
+      "Build with AI Pwani": [2026]
+    }
+  },
+  "ETH": {
+    "Name": "Ethiopia",
+    "Members in this country": true
+  },
+  "SSD": {
+    "Name": "South Sudan",
+    "Members in this country": true
+  },
+  "MDG": {
+    "Name": "Madagascar",
+    "Members in this country": true
+  },
+  "MOZ": {
+    "Name": "Mozambique",
+    "Members in this country": true
+  },
+  "CMR": {
+    "Name": "Cameroon",
+    "Sponsored": {
+      "PyCon Cameroon": [2026]
+    }
+  }
 }

--- a/_data/sponsored_events.json
+++ b/_data/sponsored_events.json
@@ -20,8 +20,8 @@
       "South America": ["Ubuntu Tech - Colombia", "Django Girls - Colombia"]
     },
     "2026": {
-      "Africa": ["PyCon Namibia"],
-      "North America": ["PyCascades"]
+      "Africa": ["PyCon Namibia", "Django Girls - Tamale", "PyCon Cameroon", "Build with AI Pwani"],
+      "North America": ["PyCascades", "PyTexas", "PyNorth Meetups"]
     }
   }
 }

--- a/_layouts/_includes/sponsored-events.html
+++ b/_layouts/_includes/sponsored-events.html
@@ -16,6 +16,7 @@
 
   <section>
     <h2>Events Sponsored by year</h2>
+    <p><em>Note: Some events listed here are community sponsorships in which no money was transferred between parties. These reflect partnerships where Black Python Devs contributed visibility, volunteer time, or other non-monetary support.</em></p>
     {% for segment_year in data.sponsored | sort(reverse=True) %}
       {% if segment_year == year %}
         <details name="{{segment_year}}" open>

--- a/runbooks/add-sponsored-event.md
+++ b/runbooks/add-sponsored-event.md
@@ -16,14 +16,38 @@ Sponsored events are listed on the homepage and the About page, rendered from
 
 ## Add a sponsored event
 
-1. Open `_data/sponsored_events.json`.
-2. Find the current year and the region.
-3. Append the event name. If the region doesn't exist for that year yet, add it.
-4. If it's the first event of a new year, add the year key with region sub-keys.
+Use the `add_conference` script — it updates `sponsored_events.json`,
+`map_data.json`, and regenerates `assets/map.html` in one step:
+
+```
+just add-conference --title "PyCon Cameroon" --year 2026 --continent "Africa" --country "Cameroon"
+```
+
+Or call the script directly (required when the title contains spaces and
+dashes, since `just` splits positional args):
+
+```
+uv run python scripts/add_conference.py \
+    --title "Django Girls - Tamale" \
+    --year 2026 \
+    --continent "Africa" \
+    --country "Ghana"
+```
+
+The country name is fuzzy-matched to an ISO_A3 code via `pycountry`. Valid
+continents: Africa, Antarctica, Asia, Europe, North America, Oceania,
+South America.
 
 Event names are plain strings — no URL is rendered. If you want a linked page,
 use the `bpd` list instead and create the corresponding event page under
 `events/` (e.g. `events/leadership-summit-2026-ohio.md`).
+
+### Manual edit (fallback)
+
+If the script is unavailable, edit `_data/sponsored_events.json` directly:
+find the year and region under `sponsored`, append the event name, and add
+the year/region keys if missing. Then update `_data/map_data.json` and
+re-run `uv run python scripts/map.py` to regenerate the map.
 
 ## Add a BPD-owned event
 

--- a/runbooks/add-sponsored-event.md
+++ b/runbooks/add-sponsored-event.md
@@ -23,8 +23,9 @@ Use the `add_conference` script — it updates `sponsored_events.json`,
 just add-conference --title "PyCon Cameroon" --year 2026 --continent "Africa" --country "Cameroon"
 ```
 
-Or call the script directly (required when the title contains spaces and
-dashes, since `just` splits positional args):
+Or call the script directly if you're using positional args or run into
+shell-quoting issues with `just`. Quoted flags such as `--title "PyCon
+Cameroon"` should work with `just`:
 
 ```
 uv run python scripts/add_conference.py \

--- a/scripts/map.py
+++ b/scripts/map.py
@@ -185,15 +185,16 @@ def generate_map():
 
     # Add reset zoom control using a direct approach
     # This script will be added at the end and executed immediately
-    reset_control_script = folium.Element("""
+    reset_control_script = folium.Element(
+        """
     <script>
     (function() {
         var attempts = 0;
         var maxAttempts = 50;
-        
+
         function addResetControl() {
             attempts++;
-            
+
             // Check if Leaflet is loaded
             if (typeof L === 'undefined' || !L.Control) {
                 if (attempts < maxAttempts) {
@@ -201,7 +202,7 @@ def generate_map():
                 }
                 return;
             }
-            
+
             // Define the control if not already defined
             if (!L.Control.ResetZoom) {
                 L.Control.ResetZoom = L.Control.extend({
@@ -218,7 +219,7 @@ def generate_map():
                         link.style.textAlign = 'center';
                         link.style.fontSize = '18px';
                         link.style.cursor = 'pointer';
-                        
+
                         L.DomEvent.on(link, 'click', function(e) {
                             L.DomEvent.preventDefault(e);
                             map.setView([20, 0], 2);
@@ -237,7 +238,7 @@ def generate_map():
                     return new L.Control.ResetZoom(opts);
                 };
             }
-            
+
             // Find all map divs and add the control
             var mapDivs = document.querySelectorAll('[id^="map_"]');
             var added = false;
@@ -252,13 +253,13 @@ def generate_map():
                     }
                 }
             });
-            
+
             // If we couldn't add and still have attempts, try again
             if (!added && attempts < maxAttempts) {
                 setTimeout(addResetControl, 100);
             }
         }
-        
+
         // Start the process
         if (document.readyState === 'loading') {
             document.addEventListener('DOMContentLoaded', addResetControl);
@@ -268,8 +269,9 @@ def generate_map():
         }
     })();
     </script>
-    """)
-    
+    """
+    )
+
     m.get_root().html.add_child(reset_control_script)
 
     # Save


### PR DESCRIPTION
## Summary
- Adds 5 events to the 2026 supported-events list: Django Girls - Tamale (#882), PyCon Cameroon (#883), PyTexas (#884), PyNorth Meetups (#886), Build with AI Pwani (#887)
- Adds a disclaimer in the sponsored-events include noting that some events are community sponsorships with no money transferred between parties (#885)
- Updates the add-sponsored-event runbook to document the `add_conference` script flow

Closes #882, #883, #884, #885, #886, #887

## How events were added
Each event was added using the existing `scripts/add_conference.py` helper (invoked via `uv run`), which atomically:
1. Appends the event under `sponsored.<year>.<continent>` in `_data/sponsored_events.json`
2. Adds/updates the country entry (ISO_A3 resolved via `pycountry`) with the year in `_data/map_data.json`
3. Regenerates `assets/map.html` via `scripts/map.py`

Commands run:
```
uv run python scripts/add_conference.py --title "Django Girls - Tamale" --year 2026 --continent "Africa" --country "Ghana"
uv run python scripts/add_conference.py --title "PyCon Cameroon" --year 2026 --continent "Africa" --country "Cameroon"
uv run python scripts/add_conference.py --title "PyTexas" --year 2026 --continent "North America" --country "United States"
uv run python scripts/add_conference.py --title "PyNorth Meetups" --year 2026 --continent "North America" --country "Canada"
uv run python scripts/add_conference.py --title "Build with AI Pwani" --year 2026 --continent "Africa" --country "Kenya"
```

The reformatting in `_data/map_data.json` (one-value-per-line arrays) comes from `json.dumps(..., indent=2)` in the script followed by prettier — no existing data was altered semantically.

## Test plan
- [x] `just test` passes (11 passed, 1 skipped)
- [x] pre-commit hooks pass
- [x] Visual review of sponsored-events page showing disclaimer and 2026 events
- [x] Confirm activity map renders new countries (Cameroon, Kenya, Canada) with 2026 entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)