### PR TITLE
Default --year to current year and run pre-commit in add_conference script

### DIFF
--- a/scripts/add_conference.py
+++ b/scripts/add_conference.py
@@ -17,6 +17,8 @@ The ISO_A3 country code is resolved from --country via pycountry.
 """
 
 import json
+import subprocess
+from datetime import date
 from pathlib import Path
 
 import click
@@ -85,7 +87,13 @@ def update_map_data(title: str, year: int, iso: str, country: str) -> None:
 
 @click.command(help="Add a sponsored conference and regenerate the activity map.")
 @click.option("--title", required=True, help="Conference title.")
-@click.option("--year", type=int, required=True, help="Year sponsored.")
+@click.option(
+    "--year",
+    type=int,
+    default=lambda: date.today().year,
+    show_default="current year",
+    help="Year sponsored.",
+)
 @click.option(
     "--continent",
     required=True,
@@ -105,6 +113,19 @@ def main(title: str, year: int, continent: str, country: str) -> None:
     update_map_data(title, year, iso, canonical)
     click.echo("Regenerating assets/map.html ...")
     generate_map()
+    click.echo("Running pre-commit on modified files ...")
+    subprocess.run(
+        [
+            "pre-commit",
+            "run",
+            "--files",
+            str(SPONSORED_JSON),
+            str(MAP_JSON),
+            str(ROOT / "assets" / "map.html"),
+        ],
+        cwd=ROOT,
+        check=False,
+    )
     click.echo("Done.")
 
 

--- a/scripts/add_conference.py
+++ b/scripts/add_conference.py
@@ -114,18 +114,21 @@ def main(title: str, year: int, continent: str, country: str) -> None:
     click.echo("Regenerating assets/map.html ...")
     generate_map()
     click.echo("Running pre-commit on modified files ...")
-    subprocess.run(
-        [
-            "pre-commit",
-            "run",
-            "--files",
-            str(SPONSORED_JSON),
-            str(MAP_JSON),
-            str(ROOT / "assets" / "map.html"),
-        ],
-        cwd=ROOT,
-        check=False,
-    )
+    try:
+        subprocess.run(
+            [
+                "pre-commit",
+                "run",
+                "--files",
+                str(SPONSORED_JSON),
+                str(MAP_JSON),
+                str(ROOT / "assets" / "map.html"),
+            ],
+            cwd=ROOT,
+            check=False,
+        )
+    except FileNotFoundError:
+        click.echo("Skipping pre-commit (not installed).")
     click.echo("Done.")
 
 


### PR DESCRIPTION
## Issue Link 🔗:

**Issue**: N/A

## Type of Change

- [ ] Bug fix 🐞
- [x] New feature/page
- [ ] Documentation update
- [x] Other (developer ergonomics)

## Description 📋

- **What:** Updates `scripts/add_conference.py` so that `--year` defaults to the current year and the script automatically runs `pre-commit` on the files it modifies after regenerating the activity map.

- **Why:** Adding a conference for the current year is the common case, so making `--year` optional removes friction. Running pre-commit on the touched files ensures generated output (sponsored conferences JSON, map data, `assets/map.html`) is always formatted consistently before being committed.

- **How:** Contributors invoking `uv run scripts/add_conference.py` no longer need to pass `--year` for the current year, and won't need to remember a separate `pre-commit run` step before committing.

## Checklist ✅

- [x] Followed the [Code of Conduct](https://github.com/BlackPythonDevs/blackpythondevs.github.io?tab=coc-ov-file) and [Contribution Guide](https://github.com/BlackPythonDevs/blackpythondevs.github.io/blob/469afd71943738b7209bfe56d5a4e35394fbaafc/CONTRIBUTING.md)
- [x] Ran `pre-commit run --all`
- [x] All tests pass locally
- [ ] Added tests (if applicable)
- [ ] Documentation updated (if applicable)

## Additional Notes & Screenshots

These changes were created via a Claude Code prompt. The pre-commit invocation uses `check=False` so a formatting fixup doesn't error out the CLI — contributors just re-stage the resulting changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)