### PR TITLE
Fix link to donate on PyCon blog

### DIFF
--- a/_posts/2026-05-13-bpd-at-pycon-us.md
+++ b/_posts/2026-05-13-bpd-at-pycon-us.md
@@ -34,4 +34,4 @@ Shirts are available for those who donate at $35. Jackets are at $100.
 
 It will be first come first serve so make sure you donate as fast as possible.
 
-<a href="/sponsor.html" role="button">DONATE</a>
+<a href="/support.html" role="button">DONATE</a>


### PR DESCRIPTION
## Issue Link 🔗:

**Issue**: Reported in Discord

## Type of Change

- [x] Bug fix 🐞
- [ ] New feature/page
- [ ] Documentation update
- [ ] Other

## Description 📋

Corrected the donate link on the PyCon US blog post from `/sponsor.html` to `/support.html`.

## Checklist ✅

- [x] Followed the [Code of Conduct](https://github.com/BlackPythonDevs/blackpythondevs.github.io?tab=coc-ov-file) and [Contribution Guide](https://github.com/BlackPythonDevs/blackpythondevs.github.io/blob/469afd71943738b7209bfe56d5a4e35394fbaafc/CONTRIBUTING.md)
- [x] Ran `pre-commit run --all`
- [x] All tests pass locally
- [ ] Added tests (if applicable)
- [ ] Documentation updated (if applicable)