### PR TITLE
Link sponsor logos to their websites

### DIFF
--- a/_layouts/_includes/sponsors.html
+++ b/_layouts/_includes/sponsors.html
@@ -2,19 +2,29 @@
   <h3>Corporate Sponsors</h3>
   <div class="grid">
     <article class="sponsor">
-      <img src="/assets/images/gnome-foundation-blue.png" alt="GNOME Foundation Logo" style="height: 2rem" />
+      <a href="https://foundation.gnome.org/" target="_blank" rel="noopener">
+        <img src="/assets/images/gnome-foundation-blue.png" alt="GNOME Foundation Logo" style="height: 2rem" />
+      </a>
     </article>
     <article class="sponsor">
-      <img src="/assets/images/2020_Anaconda_Logo_RGB_Corporate.png" alt="Anaconda Logo" style="height: 2rem" />
+      <a href="https://www.anaconda.com/" target="_blank" rel="noopener">
+        <img src="/assets/images/2020_Anaconda_Logo_RGB_Corporate.png" alt="Anaconda Logo" style="height: 2rem" />
+      </a>
     </article>
     <article class="sponsor">
-      <img src="/assets/images/jetbrains.webp" alt="JetBrains Logo" style="height: 2rem" />
+      <a href="https://www.jetbrains.com/" target="_blank" rel="noopener">
+        <img src="/assets/images/jetbrains.webp" alt="JetBrains Logo" style="height: 2rem" />
+      </a>
     </article>
     <article class="sponsor">
-      <img src="/assets/images/pydantic-lg.webp" alt="JetBrains Logo" style="height: 2rem" />
+      <a href="https://pydantic.dev/" target="_blank" rel="noopener">
+        <img src="/assets/images/pydantic-lg.webp" alt="Pydantic Logo" style="height: 2rem" />
+      </a>
     </article>
     <article class="sponsor">
-      <img src="/assets/images/revsys.webp" alt="REVSYS Logo" style="height: 2rem" />
+      <a href="https://www.revsys.com/" target="_blank" rel="noopener">
+        <img src="/assets/images/revsys.webp" alt="REVSYS Logo" style="height: 2rem" />
+      </a>
     </article>
     <article>
       <p><a href="/corporate-sponsorships.html">Learn more about corporate sponsorships</a></p>


### PR DESCRIPTION
## Summary
- Wrap each corporate sponsor logo in a link to the sponsor's homepage (opens in a new tab)
- GNOME Foundation → https://foundation.gnome.org/, Anaconda, JetBrains, Pydantic, REVSYS
- Fix Pydantic logo `alt` text that was mistakenly "JetBrains Logo"

Closes #931

🤖 Generated with [Claude Code](https://claude.com/claude-code)