### PR TITLE
Give sponsor logos a consistent light background in both themes

### DIFF
--- a/assets/css/bpd.css
+++ b/assets/css/bpd.css
@@ -1411,7 +1411,14 @@ main.page-content div.wrapper p img {
 .sponsor {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 1rem;
+  /* Fixed light background in both themes so full-color sponsor
+     logos stay legible in dark mode (issue #933, option C) */
+  background: #ffffff;
+  border: 1px solid var(--bpd-border);
+  border-radius: 12px;
+  padding: 1.25rem 1.5rem;
 }
 .post-title > h3 {
   font-size: smaller;


### PR DESCRIPTION
Fixes #933

Implements option C from the issue discussion: instead of swapping or recoloring logos (which would need sponsor approval), each sponsor card now gets a fixed white background with padding and a rounded border. The background stays the same in light and dark mode, so the full-color logos remain legible everywhere. Single CSS change to the `.sponsor` rule in `assets/css/bpd.css`.

## Screenshots

_Dark mode:_


<img width="1052" height="225" alt="sponsors-dark" src="https://github.com/user-attachments/assets/9ac4f45f-cbe8-4230-acb3-36005c009b3f" />

_Light mode:_

<img width="1052" height="225" alt="sponsors-light" src="https://github.com/user-attachments/assets/660d9622-7f77-4c74-8ba1-0e54c3bdf067" />
